### PR TITLE
Rendering suggestions

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-# Table of Content
+# Table of Contents
 
 ```{toctree}
 ---


### PR DESCRIPTION
the PR is just a spelling change, but here are additional suggestions:

- Can we change the headings under the Table of Contents to be:
"Photometry" (instead of "Multi-band forced photometry) and "Time Domain"

- Then the "Photometry" heading doesn't need to be a link to a page with a link to the notebook.  Since there is only one notebook in that heading, I think it is fine to not have the heading be a link.  The notebook title under it will be the link.

- Inside the rendered notebooks, I don't need the orange # that appears next to the headings when I hover over them and appears to move that section to the top.  This is just a preference and not a strong opinion.

- For the forced photometry rendered notebook, the section heading doesn't appear to have worked for section 2.  I think "Use fornax cloud access API..." should be 2.1, etc.  Sorry if this is a problem with the original notebook, and leet me know if you want me to change anything in the .md file

- Issue #196 is already opened to edit the text blurbs in the intro readme file which will propagate to here.
