### PR TITLE
commenting out herschel module

### DIFF
--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -241,6 +241,7 @@ df_spec.append(df_spec_HST)
 ### 2.3 ESA Archive
 ```python
 # Herschel PACS & SPIRE from ESA TAP using astroquery
+
 herschel_radius = 1.1  
 herschel_download_directory = 'data/herschel'
 if not os.path.exists(herschel_download_directory):


### PR DESCRIPTION
super small PR to
- complete the table at the top of the code to indicate the source of the herschel data
- comment out the lines in the herschel module which do the actual work.

In the SP meeting Jul/24 we decided that this module is functional but too slow to include.  We will leave it commented out in the notebook so that CI/CD can run, and people can use it if they like, but the whole notebook will not be slowed down by the herschel archive.  