### PR TITLE
Change unWISE bucket to nasa-irsa-wise

### DIFF
--- a/light_curves/code_src/wise_functions.py
+++ b/light_curves/code_src/wise_functions.py
@@ -100,9 +100,9 @@ def load_lightcurves(locations, radius, bandlist):
     """
     # the catalog is stored in an AWS S3 bucket in region us-east-1
     # load the catalog's metadata as a pyarrow dataset. this will be used to query the catalog
-    fs = pyarrow.fs.S3FileSystem(region="us-east-1")
-    bucket = "irsa-mast-tike-spitzer-data"
-    catalog_root = f"{bucket}/data/NEOWISE/healpix_k{K}/meisner-etal/neo7/meisner-etal-neo7.parquet"
+    fs = pyarrow.fs.S3FileSystem(region="us-west-2")
+    bucket = "nasa-irsa-wise"
+    catalog_root = f"{bucket}/unwise/neo7/catalogs/time_domain/healpix_k{K}/unwise-neo7-time_domain-healpix_k{K}.parquet"
     dataset = pyarrow.dataset.parquet_dataset(f"{catalog_root}/_metadata", filesystem=fs, partitioning="hive")
 
     # specify which columns will be loaded

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -96,9 +96,9 @@ from plot_functions import create_figures
 from sample_selection import (clean_sample, get_green_sample, get_hon_sample, get_lamassa_sample, get_lopeznavas_sample,
     get_lyu_sample, get_macleod16_sample, get_macleod19_sample, get_ruan_sample, get_sdss_sample, get_sheng_sample, get_yang_sample)
 from tess_kepler_functions import tess_kepler_get_lightcurves
-# Note: WISE and ZTF data are temporarily located in a non-public AWS S3 bucket. It is automatically
-# available from the Fornax SMCE, but will require user credentials for access outside the SMCE.
 from wise_functions import wise_get_lightcurves
+# Note: ZTF data is temporarily located in a non-public AWS S3 bucket. It is automatically available
+# from the Fornax Science Console, but otherwise will require explicit user credentials.
 from ztf_functions import ztf_get_lightcurves
 ```
 


### PR DESCRIPTION
The unWISE dataset accessed by the light curve notebooks is now in a NASA ODR bucket. This PR updates the code to access that bucket.