### PR TITLE
Remove reference to incorrect AWS region

### DIFF
--- a/light_curves/code_src/wise_functions.py
+++ b/light_curves/code_src/wise_functions.py
@@ -98,8 +98,8 @@ def load_lightcurves(locations, radius, bandlist):
     wise_df : pd.DataFrame
         dataframe of light curve data for all objects in `locations`
     """
-    # the catalog is stored in an AWS S3 bucket in region us-east-1
-    # load the catalog's metadata as a pyarrow dataset. this will be used to query the catalog
+    # load the catalog's metadata as a pyarrow dataset. this will be used to query the catalog.
+    # the catalog is stored in an AWS S3 bucket
     fs = pyarrow.fs.S3FileSystem(region="us-west-2")
     bucket = "nasa-irsa-wise"
     catalog_root = f"{bucket}/unwise/neo7/catalogs/time_domain/healpix_k{K}/unwise-neo7-time_domain-healpix_k{K}.parquet"


### PR DESCRIPTION
Removes a reference to an incorrect AWS region left over from #330 