### PR TITLE
panstarrs_get_lightcurve using lsdb

### DIFF
--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -9,7 +9,7 @@ from data_structures import MultiIndexDFObject
 
 
 #panstarrs light curves from hipscat catalog in S3 using lsdb
-def panstarrs_get_lightcurves(sample_table, radius):
+def panstarrs_get_lightcurves(sample_table, radius = 1):
     """Searches panstarrs hipscat files for light curves from a list of input coordinates.  
     
     Parameters

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -8,8 +8,8 @@ from dask.distributed import Client
 from data_structures import MultiIndexDFObject
 
 
-#panstarrs light curves from hipscat catalog in S3 using lsdb
-def panstarrs_get_lightcurves(sample_table, radius = 1):
+# panstarrs light curves from hipscat catalog in S3 using lsdb
+def panstarrs_get_lightcurves(sample_table, *, radius=1):
     """Searches panstarrs hipscat files for light curves from a list of input coordinates.  
     
     Parameters

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -125,4 +125,5 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
              band=filtername, 
              label=lab.astype(str))).set_index(["objectid","label", "band", "time"])
 
-    return df_lc
+    return MultiIndexDFObject(data=df_lc)
+    

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -8,7 +8,7 @@ from dask.distributed import Client
 from data_structures import MultiIndexDFObject
 
 
-#panstarrs light curves from hipscat catalog using LSDB
+#panstarrs light curves from hipscat catalog in S3 using lsdb
 def panstarrs_get_lightcurves(sample_table, radius):
     """Searches panstarrs hipscat files for light curves from a list of input coordinates.  
     

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -69,7 +69,7 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
 
     #plan to cross match panstarrs object with my sample 
     #only keep the best match
-    yang_ps = panstarrs_object.crossmatch(
+    matched_objects = panstarrs_object.crossmatch(
         sample_lsdb, 
         radius_arcsec=radius, 
         n_neighbors=1, 
@@ -78,7 +78,7 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
     )
         
     # plan to join that cross match with detections to get light-curves
-    yang_ps_lc = yang_ps.join(
+    matched_lc = matched_objects.join(
         panstarrs_detect,
         left_on="objID",
         right_on="objID",
@@ -91,7 +91,7 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
     with Client():
         #compute the cross match with object table
         #and the join with the detections table
-        matched_df = yang_ps_lc.compute()
+        matched_df = matched_lc.compute()
     
         
     #cleanup the filter names to the expected letters

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -25,7 +25,7 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
         the main data structure to store all light curves
     """
     
-    #read in the hipscat object table to lsdb
+    #read in the panstarrs object table to lsdb
     #this table will be used for cross matching with our sample's ra and decs
     #but does not have light curve information
     panstarrs_object = lsdb.read_hipscat(
@@ -37,7 +37,7 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
             "nStackDetections",  # some other data to use
         ]
     )
-    #read in the hipscat light curves to lsdb
+    #read in the panstarrs light curves to lsdb
     #panstarrs recommendation is not to index into this table with ra and dec
     #but to use object ids from the above object table
     panstarrs_detect = lsdb.read_hipscat(
@@ -46,7 +46,6 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
         columns=[
             "objID",  # PS1 object ID
             "detectID",  # PS1 detection ID
-            "ra", "dec",
             # light-curve stuff
             "obsTime", "filterID", "psfFlux", "psfFluxErr",
         ],

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -1,236 +1,16 @@
 import numpy as np
 import pandas as pd
-import requests
 from astropy.table import Table
-from tqdm.auto import tqdm
+import lsdb
+from dask.distributed import Client
+
 
 from data_structures import MultiIndexDFObject
 
-# code partially taken from https://ps1images.stsci.edu/ps1_dr2_api.html
-def ps1cone(ra,dec,radius,table="mean",release="dr1",format="csv",columns=None,
-           baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs", verbose=False,
-           **kw):
-    """Do a cone search of the PS1 catalog
-    
-    Parameters
-    ----------
-    ra: float (degrees) 
-        J2000 Right Ascension
-    dec: float (degrees) 
-        J2000 Declination
-    radius: float (degrees) 
-        Search radius (<= 0.5 degrees)
-    table: string
-        mean, stack, or detection
-    release: string
-        dr1 or dr2
-    format: string
-        csv, votable, json
-    columns: list of strings 
-        list of column names to include (None means use defaults)
-    baseurl: stirng
-        base URL for the request
-    verbose: int
-        print info about request
-    **kw: 
-        other parameters (e.g., 'nDetections.min':2)
-    
-    Returns
-    -------
-    cone search results
-    """
-    
-    data = kw.copy()
-    data['ra'] = ra
-    data['dec'] = dec
-    data['radius'] = radius
-    return ps1search(table=table,release=release,format=format,columns=columns,
-                    baseurl=baseurl, verbose=verbose, **data)
 
-
-def ps1search(table="mean",release="dr1",format="csv",columns=None,
-           baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs", verbose=False,
-           **kw):
-    """Do a general search of the PS1 catalog (possibly without ra/dec/radius)
-    
-    Parameters
-    ----------
-    table: string 
-        mean, stack, or detection
-    release: string 
-        dr1 or dr2
-    format: string
-        csv, votable, json
-    columns: list of strings
-        list of column names to include (None means use defaults)
-    baseurl: string
-        base URL for the request
-    verbose: int
-        print info about request
-    **kw: 
-        other parameters (e.g., 'nDetections.min':2).  Note this is required!
-    
-    Returns
-    -------
-    search results
-    """
-    
-    data = kw.copy()
-    if not data:
-        raise ValueError("You must specify some parameters for search")
-    checklegal(table,release)
-    if format not in ("csv","votable","json"):
-        raise ValueError("Bad value for format")
-    url = f"{baseurl}/{release}/{table}.{format}"
-    if columns:
-        # check that column values are legal
-        # create a dictionary to speed this up
-        dcols = {}
-        for col in ps1metadata(table,release)['name']:
-            dcols[col.lower()] = 1
-        badcols = []
-        for col in columns:
-            if col.lower().strip() not in dcols:
-                badcols.append(col)
-        if badcols:
-            raise ValueError('Some columns not found in table: {}'.format(', '.join(badcols)))
-        # two different ways to specify a list of column values in the API
-        # data['columns'] = columns
-        data['columns'] = '[{}]'.format(','.join(columns))
-
-    # either get or post works
-#    r = requests.post(url, data=data)
-    r = requests.get(url, params=data)
-
-    if verbose:
-        print(r.url)
-    r.raise_for_status()
-    if format == "json":
-        return r.json()
-    else:
-        return r.text
-
-
-def checklegal(table,release):
-    """Checks if this combination of table and release is acceptable
-    Raises a ValueError exception if there is problem
-    
-    Parameters
-    ----------
-    table: string
-        mean, stack, or detection
-    release: string
-        dr1 or dr2
-    """
-    
-    releaselist = ("dr1", "dr2")
-    if release not in ("dr1","dr2"):
-        raise ValueError("Bad value for release (must be one of {})".format(', '.join(releaselist)))
-    if release=="dr1":
-        tablelist = ("mean", "stack")
-    else:
-        tablelist = ("mean", "stack", "detection")
-    if table not in tablelist:
-        raise ValueError("Bad value for table (for {} must be one of {})".format(release, ", ".join(tablelist)))
-
-
-def ps1metadata(table="mean",release="dr1",
-           baseurl="https://catalogs.mast.stsci.edu/api/v0.1/panstarrs"):
-    """Return metadata for the specified catalog and table
-    
-    Parameters
-    ----------
-    table: string 
-        mean, stack, or detection
-    release: string 
-        dr1 or dr2
-    baseurl: string 
-        base URL for the request
-    
-    Returns
-    -------
-    astropy table with columns name, type, description
-    """
-    
-    checklegal(table,release)
-    url = f"{baseurl}/{release}/{table}/metadata"
-    r = requests.get(url)
-    r.raise_for_status()
-    v = r.json()
-    # convert to astropy table
-    tab = Table(rows=[(x['name'],x['type'],x['description']) for x in v],
-               names=('name','type','description'))
-    return tab
-
-
-def addfilter(dtab):
-    """Add filter name as column in detection table by translating filterID
-    
-    This modifies the table in place.  If the 'filter' column already exists,
-    the table is returned unchanged.
-    
-    Parameters
-    ----------
-    dtab: table
-        detection table
-        
-    Returns
-    -------
-    dtab: table
-    """
-    if 'filter' not in dtab.colnames:
-        # the filterID value goes from 1 to 5 for grizy
-        #id2filter = np.array(list('grizy'))
-        id2filter = np.array(['panstarrs g','panstarrs r','panstarrs i','panstarrs z','panstarrs y'])
-        dtab['filter'] = id2filter[(dtab['filterID']-1).data]
-    return dtab
-
-def improve_filter_format(tab):
-    """Add filter string to column name
-    Parameters
-    ----------
-    tab:table
-    
-    Returns
-    -------
-    tab: table
-    """
-    for filter in 'grizy':
-        col = filter+'MeanPSFMag'
-        tab[col].format = ".4f"
-        tab[col][tab[col] == -999.0] = np.nan
-            
-    return(tab)
-
-def search_lightcurve(objid):
-    """setup to pull light curve info
-    
-    Parameters
-    ----------
-    objid: string
-    
-    Returns
-    -------
-    dresults: search results
-    
-    """
-    dconstraints = {'objID': objid}
-    dcolumns = ("""objID,detectID,filterID,obsTime,ra,dec,psfFlux,psfFluxErr,psfMajorFWHM,psfMinorFWHM,
-            psfQfPerfect,apFlux,apFluxErr,infoFlag,infoFlag2,infoFlag3""").split(',')
-    # strip blanks and weed out blank and commented-out values
-    dcolumns = [x.strip() for x in dcolumns]
-    dcolumns = [x for x in dcolumns if x and not x.startswith('#')]
-
-
-    #get the actual detections and light curve info for this target
-    dresults = ps1search(table='detection',release='dr2',columns=dcolumns,**dconstraints)
-    
-    return(dresults)
-
-
-#Do a panstarrs search
-def panstarrs_get_lightcurves(sample_table, *, radius=1/3600):
-    """Searches panstarrs for light curves from a list of input coordinates.  This is the MAIN function.
+#panstarrs light curves from hipscat catalog using LSDB
+def panstarrs_get_lightcurves(sample_table, radius):
+    """Searches panstarrs hipscat files for light curves from a list of input coordinates.  
     
     Parameters
     ----------
@@ -244,53 +24,106 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1/3600):
     df_lc : MultiIndexDFObject
         the main data structure to store all light curves
     """
+    
+    #read in the hipscat object table to lsdb
+    #this table will be used for cross matching with our sample's ra and decs
+    #but does not have light curve information
+    panstarrs_object = lsdb.read_hipscat(
+        's3://stpubdata/panstarrs/ps1/public/hipscat/otmo', 
+        storage_options={'anon': True},
+        columns=[
+            "objID",  # PS1 ID
+            "raMean", "decMean",  # coordinates to use for cross-matching
+            "nStackDetections",  # some other data to use
+        ]
+    )
+    #read in the hipscat light curves to lsdb
+    #panstarrs recommendation is not to index into this table with ra and dec
+    #but to use object ids from the above object table
+    panstarrs_detect = lsdb.read_hipscat(
+        's3://stpubdata/panstarrs/ps1/public/hipscat/detection', 
+        storage_options={'anon': True},
+        columns=[
+            "objID",  # PS1 object ID
+            "detectID",  # PS1 detection ID
+            "ra", "dec",
+            # light-curve stuff
+            "obsTime", "filterID", "psfFlux", "psfFluxErr",
+        ],
+    )
+    #convert astropy table to pandas dataframe
+    #special care for the SkyCoords in the table
+    sample_df = pd.DataFrame({'objectid': sample_table['objectid'],
+                          'ra_deg': sample_table['coord'].ra.deg,
+                          'dec_deg':sample_table['coord'].dec.deg,
+                          'label':sample_table['label']})
+    
+    #convert dataframe to hipscat
+    sample_lsdb = lsdb.from_dataframe(
+        sample_df, 
+        ra_column="ra_deg", 
+        dec_column="dec_deg", 
+        margin_threshold=10,
+        # Optimize partition size
+        drop_empty_siblings=True
+    )
+
+    #plan to cross match panstarrs object with my sample 
+    #only keep the best match
+    yang_ps = panstarrs_object.crossmatch(
+        sample_lsdb, 
+        radius_arcsec=radius, 
+        n_neighbors=1, 
+        suffixes=("", "")
+
+    )
         
-    df_lc = MultiIndexDFObject()
+    # plan to join that cross match with detections to get light-curves
+    yang_ps_lc = yang_ps.join(
+        panstarrs_detect,
+        left_on="objID",
+        right_on="objID",
+         output_catalog_name="yang_ps_lc",
+        suffixes = ["",""]
+    )
     
-    #for all objects in our catalog
-    for row in tqdm(sample_table):
-        #doesn't take SkyCoord, convert to floats
-        ra = row["coord"].ra.deg
-        dec = row["coord"].dec.deg
-        lab = row["label"]
-        objectid = row["objectid"]
-
-        # see if there is an object in panSTARRS at this location. if not, continue to the next object.
-        results = ps1cone(ra,dec,radius,release='dr2')
-        if not results:
-            continue
-        tab = Table.read(results, format='ascii')
+    # Create default local cluster
+    # here is where the actual work gets done
+    with Client():
+        #compute the cross match with object table
+        #and the join with the detections table
+        matched_df = yang_ps_lc.compute()
     
-        # improve the format of the table
-        tab = improve_filter_format(tab)
-    
-        #in case there is more than one object within 1 arcsec, sort them by match distance
-        tab.sort('distance')
-
-        #take the closest match as the best match
-        objid = tab['objID'][0]
-
-        #get the actual detections and light curve info for this target
-        dresults = search_lightcurve(objid)
-        if not dresults:
-            continue
-    
-        #fix the column names to include filter names
-        dtab = addfilter(Table.read(dresults, format='ascii'))
-
-        dtab.sort('obsTime')
-        dtab['psfFlux'][dtab['psfFlux'] == -999.0] = np.nan
-        dtab['psfFluxErr'][dtab['psfFluxErr'] == -999.0] = np.nan
-
-        #here is the light curve mixed from all 5 bands
-        t_panstarrs = dtab['obsTime']
-        flux_panstarrs = dtab['psfFlux']*1E3  # in mJy
-        err_panstarrs = dtab['psfFluxErr'] *1E3
-        filtername = dtab['filter']
         
-        #put this single object light curves into a pandas multiindex dataframe
-        dfsingle = pd.DataFrame(dict(flux=flux_panstarrs, err=err_panstarrs, time=t_panstarrs, objectid=objectid, band=filtername, label=lab)).set_index(["objectid","label", "band", "time"])
-        #then concatenate each individual df together
-        df_lc.append(dfsingle)
-            
-    return(df_lc)
+    #cleanup the filter names to the expected letters
+    filter_id_to_name = {
+    1: 'Pan-STARRS g',
+    2: 'Pan-STARRS r',
+    3: 'Pan-STARRS i',
+    4: 'Pan-STARRS z',
+    5: 'Pan-STARRS y'
+    }
+    if len(matched_df["filterID"]) > 0:
+        get_name_from_filter_id = np.vectorize(filter_id_to_name.get)
+        filtername = get_name_from_filter_id(matched_df["filterID"])
+    else:
+        # Handle the case where the array is empty
+        filtername = []
+    
+    # setup to build dataframe 
+    t_panstarrs = matched_df["obsTime"]
+    flux_panstarrs = matched_df['psfFlux']*1E3  # in mJy
+    err_panstarrs = matched_df['psfFluxErr'] *1E3
+    lab = matched_df['label']
+    objectid = matched_df['objectid']
+
+    #make the dataframe of light curves
+    df_lc = pd.DataFrame(
+        dict(flux=pd.to_numeric(flux_panstarrs, errors='coerce').astype(np.float64), 
+             err=pd.to_numeric(err_panstarrs, errors='coerce').astype(np.float64), 
+             time=pd.to_numeric(t_panstarrs, errors='coerce').astype(np.float64), 
+             objectid=pd.to_numeric(objectid, errors='coerce').astype(np.int64), 
+             band=filtername, 
+             label=lab.astype(str))).set_index(["objectid","label", "band", "time"])
+
+    return df_lc

--- a/light_curves/code_src/plot_functions.py
+++ b/light_curves/code_src/plot_functions.py
@@ -15,7 +15,7 @@ ZTF_BANDS = ["zg", "zr", "zi"]  # will be plotted in "B" zoom-in for better visi
 OTHER_BANDS = ["F814W",  # HCV
                "FERMIGTRIG", "SAXGRBMGRB",  # HEASARC
                "G", "BP", "RP",  # Gaia
-               "panstarrs g", "panstarrs i", "panstarrs r", "panstarrs y", "panstarrs z",  # Pan-STARRS
+               "Pan-STARRS g", "Pan-STARRS i", "Pan-STARRS r", "Pan-STARRS y", "Pan-STARRS z",  # Pan-STARRS
                "W1", "W2"]  # WISE
 
 # Set a color for each band.
@@ -120,7 +120,6 @@ def _clean_lightcurves(singleobj_df):
     band_groups = singleobj.groupby("band").flux
     zscore = band_groups.transform(lambda fluxes: np.abs(stats.zscore(fluxes)))
     n_points = band_groups.transform("size")  # number of data points in the band
-    print('inside clean_lightcurves, zscore, n_points', zscore, n_points)
 
     # Keep data points with a zscore < 3 or in a band with less than 10 data points.
     singleobj = singleobj[(zscore < 3.0) | (n_points < 10)]

--- a/light_curves/code_src/plot_functions.py
+++ b/light_curves/code_src/plot_functions.py
@@ -116,11 +116,12 @@ def _clean_lightcurves(singleobj_df):
 
     # Remove rows containing NaN in time, flux, or err
     singleobj = singleobj.dropna(subset=["time", "flux", "err"])
-
     # Do sigma-clipping per band.
     band_groups = singleobj.groupby("band").flux
     zscore = band_groups.transform(lambda fluxes: np.abs(stats.zscore(fluxes)))
     n_points = band_groups.transform("size")  # number of data points in the band
+    print('inside clean_lightcurves, zscore, n_points', zscore, n_points)
+
     # Keep data points with a zscore < 3 or in a band with less than 10 data points.
     singleobj = singleobj[(zscore < 3.0) | (n_points < 10)]
 

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -74,7 +74,7 @@ This cell will install them if needed:
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-# !pip install -r requirements_light_curve_generator.txt
+!pip install -r requirements_light_curve_generator.txt
 ```
 
 ```{code-cell} ipython3
@@ -85,8 +85,6 @@ import time
 import astropy.units as u
 import pandas as pd
 from astropy.table import Table
-
-import numpy as np
 
 # local code imports
 sys.path.append('code_src/')
@@ -263,9 +261,9 @@ The function to retrieve lightcurves from Pan-STARRS uses a version of both the 
 ```{code-cell} ipython3
 panstarrsstarttime = time.time()
 
-panstarrs_search_radius = 1.0 # search radius in arcsec
+panstarrs_search_radius = 1.0 # search radius = 1 arcsec
 # get panstarrs light curves
-df_lc_panstarrs = panstarrs_get_lightcurves(sample_table, panstarrs_search_radius)
+df_lc_panstarrs = panstarrs_get_lightcurves(sample_table, radius = panstarrs_search_radius)
 
 # add the resulting dataframe to all other archives
 df_lc.append(df_lc_panstarrs)

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -419,16 +419,15 @@ parallel_df_lc.data
 
 ```{code-cell} ipython3
 # Save the data for future use with ML notebook
-#parquet_savename = f"output/{sample_name}_df_lc.parquet"
+#parquet_filename = f"output/{sample_name}_df_lc.parquet"
 #parallel_df_lc.data.to_parquet(parquet_savename)
 #print("file saved!")
 ```
 
 ```{code-cell} ipython3
 # Could load a previously saved file in order to plot
-#parquet_loadname = 'output/yang_CLAGN_df_lc.parquet'
 #parallel_df_lc = MultiIndexDFObject()
-#parallel_df_lc.data = pd.read_parquet(parquet_loadname)
+#parallel_df_lc.data = pd.read_parquet(parquet_filename)
 #print("file loaded!")
 ```
 

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -256,7 +256,7 @@ print('WISE search took:', time.time() - WISEstarttime, 's')
 ```
 
 ### 2.4 MAST: Pan-STARRS
-The function to retrieve lightcurves from Pan-STARRS uses a version of both the object and light curve catalogs that are stored in the cloud and accessd using [lsdb](https://docs.lsdb.io/en/stable/).  This function is efficient at large scale (sample sizes > ~1000).
+The function to retrieve lightcurves from Pan-STARRS uses a version of both the object and light curve catalogs that are stored in the cloud and accessed using [lsdb](https://docs.lsdb.io/en/stable/).  This function is efficient at large scale (sample sizes > ~1000).
 
 ```{code-cell} ipython3
 panstarrsstarttime = time.time()

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -273,20 +273,6 @@ print('Panstarrs search took:', time.time() - panstarrsstarttime, 's')
 # Warnings from the panstarrs query about both NESTED and margins are known issues
 ```
 
-```{code-cell} ipython3
-# Save the data for future use with ML notebook
-# parquet_savename = "output/df_lc_panstarrs.parquet"
-# df_lc.data.to_parquet(parquet_savename)
-# print("file saved!")
-
-
-# Could load a previously saved file in order to plot
-# parquet_loadname = 'output/df_lc_090723_yang.parquet'
-# df_lc = MultiIndexDFObject()
-# df_lc.data = pd.read_parquet(parquet_savename)
-# print("file loaded!")
-```
-
 ### 2.5 MAST: TESS, Kepler and K2
 The function to retrieve lightcurves from these three missions currently uses the open source package [`lightKurve`](https://docs.lightkurve.org/index.html).  This search is not efficient at scale and we expect it to be replaced in the future.
 

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -74,7 +74,7 @@ This cell will install them if needed:
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-!pip install -r requirements_light_curve_generator.txt
+# !pip install -r requirements_light_curve_generator.txt
 ```
 
 ```{code-cell} ipython3
@@ -133,9 +133,9 @@ get_yang_sample(coords, labels)   #2018ApJ...862..109Y
 # a balance between speed of running the light curves and whatever
 # the ML algorithms would like to have
 
-#num_normal_QSO = 30
-#zmin, zmax = 0, 10
-#randomize_z = False
+# num_normal_QSO = 5000
+# zmin, zmax = 0, 10
+# randomize_z = False
 #get_sdss_sample(coords, labels, num=num_normal_QSO, zmin=zmin, zmax=zmax, randomize_z=randomize_z)
 
 # Remove duplicates, attach an objectid to the coords,
@@ -263,7 +263,7 @@ panstarrsstarttime = time.time()
 
 panstarrs_search_radius = 1.0 # search radius = 1 arcsec
 # get panstarrs light curves
-df_lc_panstarrs = panstarrs_get_lightcurves(sample_table, radius = panstarrs_search_radius)
+df_lc_panstarrs = panstarrs_get_lightcurves(sample_table, radius=panstarrs_search_radius)
 
 # add the resulting dataframe to all other archives
 df_lc.append(df_lc_panstarrs)

--- a/light_curves/requirements_light_curve_classifier.txt
+++ b/light_curves/requirements_light_curve_classifier.txt
@@ -5,7 +5,7 @@ numpy
 pandas[parquet]
 matplotlib
 astropy
-sktime
+sktime<0.32
 tqdm
 googledrivedownloader
 scikit-learn

--- a/light_curves/requirements_light_curve_generator.txt
+++ b/light_curves/requirements_light_curve_generator.txt
@@ -15,8 +15,8 @@ acstools
 lightkurve
 alerce
 lsdb
-s3fs
-nested_pandas
+#s3fs
+#nested_pandas
 # Required by functionality we use from acstools
 scikit-image
 # Required for sensible progress bars

--- a/light_curves/requirements_light_curve_generator.txt
+++ b/light_curves/requirements_light_curve_generator.txt
@@ -14,6 +14,9 @@ astroquery>=0.4.8.dev0
 acstools
 lightkurve
 alerce
+lsdb
+s3fs
+nested_pandas
 # Required by functionality we use from acstools
 scikit-image
 # Required for sensible progress bars

--- a/light_curves/requirements_light_curve_generator.txt
+++ b/light_curves/requirements_light_curve_generator.txt
@@ -15,8 +15,7 @@ acstools
 lightkurve
 alerce
 lsdb
-#s3fs
-#nested_pandas
+dask[distributed]
 # Required by functionality we use from acstools
 scikit-image
 # Required for sensible progress bars

--- a/light_curves/requirements_light_curve_generator.txt
+++ b/light_curves/requirements_light_curve_generator.txt
@@ -15,6 +15,8 @@ acstools
 lightkurve
 alerce
 lsdb
+# We use distributed in this notebook, but installing any dask would make the [dataframe] extras required by dependencies for other notebooks. 
+# It feels to be the cleanest solution to add the dependency here as we don't directly use it elsewhere. 
 dask[distributed,dataframe]
 # Required by functionality we use from acstools
 scikit-image

--- a/light_curves/requirements_light_curve_generator.txt
+++ b/light_curves/requirements_light_curve_generator.txt
@@ -15,7 +15,7 @@ acstools
 lightkurve
 alerce
 lsdb
-dask[distributed]
+dask[distributed,dataframe]
 # Required by functionality we use from acstools
 scikit-image
 # Required for sensible progress bars


### PR DESCRIPTION
having some trouble catching exceptions for FileNotFound in the call to lsdb's crossmatch with the Panstarrs catalog.  It would be nice if we could somehow catch this error so that the crossmatch doesn't fail if a file is missing.  Instead, it would be ideal if one of the objects fails the crossmatch, that the crossmatch still finishes with the other objects complete, and the final result just looks like no match was found for that trouble-causing object/file.  

Helpdesk request submitted to MAST 9/19 about the missing file.