### PR TITLE
Reduce indentation by inverting `if` conditions

### DIFF
--- a/spectroscopy/code_src/desi_functions.py
+++ b/spectroscopy/code_src/desi_functions.py
@@ -54,47 +54,50 @@ def DESIBOSS_get_spec(sample_table, search_radius_arcsec):
                 }
         found_I = client.find(outfields=out, constraints=cons, limit=20)  # search
         # print(found_I)
+        if len(found_I.records) == 0:
+            continue
 
         # Extract nice table and the spectra
-        if len(found_I.records) > 0:
-            result_tab = Table(names=found_I.records[0].keys(), dtype=[type(
-                found_I.records[0][key]) for key in found_I.records[0].keys()])
-            _ = [result_tab.add_row([f[key] for key in f.keys()]) for f in found_I.records]
+        result_tab = Table(names=found_I.records[0].keys(), dtype=[type(
+            found_I.records[0][key]) for key in found_I.records[0].keys()])
+        _ = [result_tab.add_row([f[key] for key in f.keys()]) for f in found_I.records]
 
-            sep = [search_coords.separation(SkyCoord(tt["ra"], tt["dec"], unit=u.deg, frame='icrs')).to(
-                u.arcsecond).value for tt in result_tab]
-            result_tab["separation"] = sep
+        sep = [search_coords.separation(SkyCoord(tt["ra"], tt["dec"], unit=u.deg, frame='icrs')).to(
+            u.arcsecond).value for tt in result_tab]
+        result_tab["separation"] = sep
 
-            # Retrieve Spectra
-            inc = ['sparcl_id', 'specid', 'data_release', 'redshift', 'flux',
-                   'wavelength', 'model', 'ivar', 'mask', 'spectype', 'ra', 'dec']
-            results_I = client.retrieve(uuid_list=found_I.ids, include=inc)
-            specs = [Spectrum1D(spectral_axis=r.wavelength*u.AA,
-                                flux=np.array(r.flux) * 10**-17 * u.Unit('erg cm-2 s-1 AA-1'),
-                                uncertainty=nddata.InverseVariance(np.array(r.ivar)),
-                                redshift=r.redshift,
-                                mask=r.mask)
-                     for r in results_I.records]
+        # Retrieve Spectra
+        inc = ['sparcl_id', 'specid', 'data_release', 'redshift', 'flux',
+               'wavelength', 'model', 'ivar', 'mask', 'spectype', 'ra', 'dec']
+        results_I = client.retrieve(uuid_list=found_I.ids, include=inc)
+        specs = [Spectrum1D(spectral_axis=r.wavelength*u.AA,
+                            flux=np.array(r.flux) * 10**-17 * u.Unit('erg cm-2 s-1 AA-1'),
+                            uncertainty=nddata.InverseVariance(np.array(r.ivar)),
+                            redshift=r.redshift,
+                            mask=r.mask)
+                 for r in results_I.records]
 
-            # Choose objects
-            for dr in data_releases:
+        # Choose objects
+        for dr in data_releases:
 
-                sel = np.where(result_tab["data_release"] == dr)[0]
-                if len(sel) > 0:  # found entry
-                    idx_closest = sel[np.where(result_tab["separation"][sel] == np.nanmin(
-                        result_tab["separation"][sel]))[0][0]]
+            sel = np.where(result_tab["data_release"] == dr)[0]
+            if len(sel) == 0:
+                continue
 
-                    # create MultiIndex Object
-                    dfsingle = pd.DataFrame(dict(wave=[specs[idx_closest].spectral_axis],
-                                                 flux=[specs[idx_closest].flux],
-                                                 err=[
-                                                     np.sqrt(1/specs[idx_closest].uncertainty.quantity)],
-                                                 label=[stab["label"]],
-                                                 objectid=[stab["objectid"]],
-                                                 mission=[dr],
-                                                 instrument=[dr],
-                                                 filter=["optical"],
-                                                 )).set_index(["objectid", "label", "filter", "mission"])
-                    df_spec.append(dfsingle)
+            idx_closest = sel[np.where(result_tab["separation"][sel] == np.nanmin(
+                result_tab["separation"][sel]))[0][0]]
+
+            # create MultiIndex Object
+            dfsingle = pd.DataFrame(dict(wave=[specs[idx_closest].spectral_axis],
+                                         flux=[specs[idx_closest].flux],
+                                         err=[
+                np.sqrt(1/specs[idx_closest].uncertainty.quantity)],
+                label=[stab["label"]],
+                objectid=[stab["objectid"]],
+                mission=[dr],
+                instrument=[dr],
+                filter=["optical"],
+            )).set_index(["objectid", "label", "filter", "mission"])
+            df_spec.append(dfsingle)
 
     return df_spec

--- a/spectroscopy/code_src/keck_functions.py
+++ b/spectroscopy/code_src/keck_functions.py
@@ -35,52 +35,47 @@ def KeckDEIMOS_get_spec(sample_table, search_radius_arcsec):
                                 spatial="Cone", radius=search_radius_arcsec * u.arcsec)
         print("Number of entries found: {}".format(len(tab)))
 
-        if len(tab) > 0:  # found a source
+        if len(tab) == 0:
+            continue
 
-            # If multiple entries are found, pick the closest.
-            if len(tab) > 1:
-                print("More than 1 entry found - pick the closest. ")
-                sep = [search_coords.separation(SkyCoord(tt["ra"], tt["dec"], unit=u.deg, frame='icrs')).to(
-                    u.arcsecond).value for tt in tab]
-                id_min = np.where(sep == np.nanmin(sep))[0]
-                tab_final = tab[id_min]
-            else:
-                tab_final = tab.copy()
+        # If multiple entries are found, pick the closest.
+        if len(tab) > 1:
+            print("More than 1 entry found - pick the closest. ")
+            sep = [search_coords.separation(SkyCoord(tt["ra"], tt["dec"], unit=u.deg, frame='icrs')).to(
+                u.arcsecond).value for tt in tab]
+            id_min = np.where(sep == np.nanmin(sep))[0]
+            tab_final = tab[id_min]
+        else:
+            tab_final = tab.copy()
 
-            if "_acal" in tab_final["fits1d"][0]:
-                ISCALIBRATED = True
-            else:
-                print("no calibration is available")
-                ISCALIBRATED = False
+        if "_acal" not in tab_final["fits1d"][0]:
+            print("no calibration is available")
+            continue
 
-            if ISCALIBRATED:  # only if calibrated spectrum is available
+        # Now extract spectrum
+        # ASCII 1d spectrum for file spec1d.cos0.034.VD_07891
+        # wavelength in Angstroms and observed-frame
+        # flux (f_lambda) in 1e-17 erg/s/cm2/A if calibrated, else in counts
+        # ivar (inverse variance) in 1e-17 erg/s/cm2/A if calibrated, else in counts
+        # wavelength flux ivar
+        url = "https://irsa.ipac.caltech.edu{}".format(tab_final["fits1d"][0].split("\"")[1])
+        spec = Table.read(url)
 
-                # Now extract spectrum
-                # ASCII 1d spectrum for file spec1d.cos0.034.VD_07891
-                # wavelength in Angstroms and observed-frame
-                # flux (f_lambda) in 1e-17 erg/s/cm2/A if calibrated, else in counts
-                # ivar (inverse variance) in 1e-17 erg/s/cm2/A if calibrated, else in counts
-                # wavelength flux ivar
-                url = "https://irsa.ipac.caltech.edu{}".format(
-                    tab_final["fits1d"][0].split("\"")[1])
-                spec = Table.read(url)
+        # Prepare arrays
+        wave = spec["LAMBDA"][0] * u.angstrom
+        flux_cgs = spec["FLUX"][0] * 1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
+        error_cgs = np.sqrt(1 / spec["IVAR"][0]) * 1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
 
-                # Prepare arrays
-                wave = spec["LAMBDA"][0] * u.angstrom
-                flux_cgs = spec["FLUX"][0] * 1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
-                error_cgs = np.sqrt(1 / spec["IVAR"][0]) * 1e-17 * \
-                    u.erg/u.second/u.centimeter**2/u.angstrom
-
-                # Create MultiIndex object
-                dfsingle = pd.DataFrame(dict(wave=[wave],
-                                             flux=[flux_cgs],
-                                             err=[error_cgs],
-                                             label=[stab["label"]],
-                                             objectid=[stab["objectid"]],
-                                             mission=["Keck"],
-                                             instrument=["DEIMOS"],
-                                             filter=["optical"],
-                                             )).set_index(["objectid", "label", "filter", "mission"])
-                df_spec.append(dfsingle)
+        # Create MultiIndex object
+        dfsingle = pd.DataFrame(dict(wave=[wave],
+                                     flux=[flux_cgs],
+                                     err=[error_cgs],
+                                     label=[stab["label"]],
+                                     objectid=[stab["objectid"]],
+                                     mission=["Keck"],
+                                     instrument=["DEIMOS"],
+                                     filter=["optical"],
+                                     )).set_index(["objectid", "label", "filter", "mission"])
+        df_spec.append(dfsingle)
 
     return df_spec

--- a/spectroscopy/code_src/mast_functions.py
+++ b/spectroscopy/code_src/mast_functions.py
@@ -105,89 +105,88 @@ def JWST_get_spec_helper(sample_table, search_radius_arcsec, datadir, verbose,
                                                     )
         print("Number of search results: {}".format(len(query_results)))
 
-        if len(query_results) > 0:  # found some spectra
-
-            # Retrieve spectra
-            data_products_list = Observations.get_product_list(query_results)
-
-            # Filter
-            data_products_list_filter = Observations.filter_products(data_products_list,
-                                                                     productType=["SCIENCE"],
-                                                                     # filters=['CLEAR;PRISM','F070LP;G140M'],
-                                                                     # filters=['CLEAR;PRISM'],
-                                                                     extension="fits",
-                                                                     # only fully reduced or contributed
-                                                                     calib_level=[3, 4],
-                                                                     productSubGroupDescription=[
-                                                                         "X1D"],  # only 1D spectra
-                                                                     # only public data
-                                                                     dataRights=['PUBLIC']
-                                                                     )
-            print("Number of files to download: {}".format(len(data_products_list_filter)))
-
-            if len(data_products_list_filter) > 0:
-
-                # Download (supress output)
-                trap = io.StringIO()
-                with redirect_stdout(trap):
-                    download_results = Observations.download_products(
-                        data_products_list_filter, download_dir=this_data_dir)
-                if verbose:
-                    print(trap.getvalue())
-
-                # Create table
-                # NOTE: `download_results` has NOT the same order as `data_products_list_filter`.
-                # We therefore have to "manually" get the product file names here and then use
-                # those to open the files.
-                keys = ["filters", "obs_collection", "instrument_name", "calib_level",
-                        "t_obs_release", "proposal_id", "obsid", "objID", "distance"]
-                tab = Table(names=keys + ["productFilename"], dtype=[str,
-                            str, str, int, float, int, int, int, float]+[str])
-                for jj in range(len(data_products_list_filter)):
-                    idx_cross = np.where(query_results["obsid"] ==
-                                         data_products_list_filter["obsID"][jj])[0]
-                    tmp = query_results[idx_cross][keys]
-                    tab.add_row(list(tmp[0]) + [data_products_list_filter["productFilename"][jj]])
-                # print("number in table {}".format(len(tab)))
-
-                # Create multi-index object
-                for jj in range(len(tab)):
-
-                    # find correct path name:
-                    # Note that `download_results` does NOT have same order as `tab`!!
-                    file_idx = np.where([tab["productFilename"][jj] in download_results["Local Path"][iii]
-                                        for iii in range(len(download_results))])[0]
-
-                    # open spectrum
-                    # Note that specutils returns the wrong units. Use Table.read() instead.
-                    filepath = download_results["Local Path"][file_idx[0]]
-                    spec1d = Table.read(filepath, hdu=1)
-
-                    # print(filepath)
-                    # spec1d = Spectrum1D.read(filepath)
-
-                    dfsingle = pd.DataFrame(dict(
-                        wave=[spec1d["WAVELENGTH"].data * spec1d["WAVELENGTH"].unit],
-                        flux=[spec1d["FLUX"].data * spec1d["FLUX"].unit],
-                        err=[spec1d["FLUX_ERROR"].data *
-                             spec1d["FLUX_ERROR"].unit],
-                        label=[stab["label"]],
-                        objectid=[stab["objectid"]],
-                        # objID=[tab["objID"][jj]], # REMOVE
-                        # obsid=[tab["obsid"][jj]],
-                        mission=[tab["obs_collection"][jj]],
-                        instrument=[tab["instrument_name"][jj]],
-                        filter=[tab["filters"][jj]],
-                    )).set_index(["objectid", "label", "filter", "mission"])
-                    df_spec.append(dfsingle)
-
-                if delete_downloaded_data:
-                    shutil.rmtree(this_data_dir)
-
-            else:
-                print("Nothing to download for source {}.".format(stab["label"]))
-        else:
+        if len(query_results) == 0:
             print("Source {} could not be found".format(stab["label"]))
+            continue
+
+        # Retrieve spectra
+        data_products_list = Observations.get_product_list(query_results)
+
+        # Filter
+        data_products_list_filter = Observations.filter_products(data_products_list,
+                                                                 productType=["SCIENCE"],
+                                                                 # filters=['CLEAR;PRISM','F070LP;G140M'],
+                                                                 # filters=['CLEAR;PRISM'],
+                                                                 extension="fits",
+                                                                 # only fully reduced or contributed
+                                                                 calib_level=[3, 4],
+                                                                 productSubGroupDescription=[
+                                                                     "X1D"],  # only 1D spectra
+                                                                 # only public data
+                                                                 dataRights=['PUBLIC']
+                                                                 )
+        print("Number of files to download: {}".format(len(data_products_list_filter)))
+
+        if len(data_products_list_filter) == 0:
+            print("Nothing to download for source {}.".format(stab["label"]))
+            continue
+
+        # Download (supress output)
+        trap = io.StringIO()
+        with redirect_stdout(trap):
+            download_results = Observations.download_products(
+                data_products_list_filter, download_dir=this_data_dir)
+        if verbose:
+            print(trap.getvalue())
+
+        # Create table
+        # NOTE: `download_results` has NOT the same order as `data_products_list_filter`.
+        # We therefore have to "manually" get the product file names here and then use
+        # those to open the files.
+        keys = ["filters", "obs_collection", "instrument_name", "calib_level",
+                "t_obs_release", "proposal_id", "obsid", "objID", "distance"]
+        tab = Table(names=keys + ["productFilename"], dtype=[str,
+                    str, str, int, float, int, int, int, float]+[str])
+        for jj in range(len(data_products_list_filter)):
+            idx_cross = np.where(query_results["obsid"] ==
+                                 data_products_list_filter["obsID"][jj])[0]
+            tmp = query_results[idx_cross][keys]
+            tab.add_row(list(tmp[0]) + [data_products_list_filter["productFilename"][jj]])
+        # print("number in table {}".format(len(tab)))
+
+        # Create multi-index object
+        for jj in range(len(tab)):
+
+            # find correct path name:
+            # Note that `download_results` does NOT have same order as `tab`!!
+            file_idx = np.where([tab["productFilename"][jj] in download_results["Local Path"][iii]
+                                for iii in range(len(download_results))])[0]
+
+            # open spectrum
+            # Note that specutils returns the wrong units. Use Table.read() instead.
+            filepath = download_results["Local Path"][file_idx[0]]
+            spec1d = Table.read(filepath, hdu=1)
+
+            # print(filepath)
+            # spec1d = Spectrum1D.read(filepath)
+
+            dfsingle = pd.DataFrame(dict(
+                wave=[spec1d["WAVELENGTH"].data * spec1d["WAVELENGTH"].unit],
+                flux=[spec1d["FLUX"].data * spec1d["FLUX"].unit],
+                err=[spec1d["FLUX_ERROR"].data *
+                     spec1d["FLUX_ERROR"].unit],
+                label=[stab["label"]],
+                objectid=[stab["objectid"]],
+                # objID=[tab["objID"][jj]], # REMOVE
+                # obsid=[tab["obsid"][jj]],
+                mission=[tab["obs_collection"][jj]],
+                instrument=[tab["instrument_name"][jj]],
+                filter=[tab["filters"][jj]],
+            )).set_index(["objectid", "label", "filter", "mission"])
+            df_spec.append(dfsingle)
+
+        if delete_downloaded_data:
+            shutil.rmtree(this_data_dir)
 
     return df_spec
 
@@ -246,44 +245,46 @@ def JWST_group_spectra(df, verbose, quickplot):
             if verbose:
                 print("Number of good spectra: {}".format(len(idx_good)))
 
-            if len(idx_good) > 0:
-                # Create wavelength grid
-                wave_grid = tab_sel.iloc[idx_good[0]]["wave"]  # NEED TO BE MADE BETTER LATER
+            if len(idx_good) == 0:
+                continue
 
-                # Interpolate fluxes
-                fluxes_int = np.asarray(
-                    [np.interp(wave_grid, tab_sel.iloc[idx]["wave"], tab_sel.iloc[idx]["flux"]) for idx in idx_good])
-                fluxes_units = [tab_sel.iloc[idx]["flux"].unit for idx in idx_good]
-                fluxes_stack = np.nanmedian(fluxes_int, axis=0)
-                if verbose:
-                    print("Units of fluxes for each spectrum: {}".format(
-                        ",".join([str(tt) for tt in fluxes_units])))
+            # Create wavelength grid
+            wave_grid = tab_sel.iloc[idx_good[0]]["wave"]  # NEED TO BE MADE BETTER LATER
 
-                # Unit conversion to erg/s/cm2/A
-                # (note fluxes are nominally in Jy. So have to do the step with dividing by lam^2)
-                fluxes_stack_cgs = (fluxes_stack * fluxes_units[0]).to(u.erg / u.second / (
-                    u.centimeter**2) / u.hertz) * (const.c.to(u.angstrom/u.second)) / (wave_grid.to(u.angstrom)**2)
-                fluxes_stack_cgs = fluxes_stack_cgs.to(
-                    u.erg / u.second / (u.centimeter**2) / u.angstrom)
+            # Interpolate fluxes
+            fluxes_int = np.asarray(
+                [np.interp(wave_grid, tab_sel.iloc[idx]["wave"], tab_sel.iloc[idx]["flux"]) for idx in idx_good])
+            fluxes_units = [tab_sel.iloc[idx]["flux"].unit for idx in idx_good]
+            fluxes_stack = np.nanmedian(fluxes_int, axis=0)
+            if verbose:
+                print("Units of fluxes for each spectrum: {}".format(
+                    ",".join([str(tt) for tt in fluxes_units])))
 
-                # Add to data frame
-                dfsingle = pd.DataFrame(dict(wave=[wave_grid.to(u.micrometer)], flux=[fluxes_stack_cgs], err=[np.repeat(0, len(fluxes_stack_cgs))],
-                                             label=[tab_sel["label"].iloc[0]],
-                                             objectid=[tab_sel["objectid"].iloc[0]],
-                                             mission=[tab_sel["mission"].iloc[0]],
-                                             instrument=[tab_sel["instrument"].iloc[0]],
-                                             filter=[tab_sel["filter"].iloc[0]],
-                                             )).set_index(["objectid", "label", "filter", "mission"])
-                df_spec.append(dfsingle)
+            # Unit conversion to erg/s/cm2/A
+            # (note fluxes are nominally in Jy. So have to do the step with dividing by lam^2)
+            fluxes_stack_cgs = (fluxes_stack * fluxes_units[0]).to(u.erg / u.second / (
+                u.centimeter**2) / u.hertz) * (const.c.to(u.angstrom/u.second)) / (wave_grid.to(u.angstrom)**2)
+            fluxes_stack_cgs = fluxes_stack_cgs.to(
+                u.erg / u.second / (u.centimeter**2) / u.angstrom)
 
-                # Quick plot
-                if quickplot:
-                    tmp = np.percentile(fluxes_stack, q=(1, 50, 99))
-                    plt.plot(wave_grid, fluxes_stack)
-                    plt.ylim(tmp[0], tmp[2])
-                    plt.xlabel(r"Observed Wavelength [$\mu$m]")
-                    plt.ylabel(r"Flux [Jy]")
-                    plt.show()
+            # Add to data frame
+            dfsingle = pd.DataFrame(dict(wave=[wave_grid.to(u.micrometer)], flux=[fluxes_stack_cgs], err=[np.repeat(0, len(fluxes_stack_cgs))],
+                                         label=[tab_sel["label"].iloc[0]],
+                                         objectid=[tab_sel["objectid"].iloc[0]],
+                                         mission=[tab_sel["mission"].iloc[0]],
+                                         instrument=[tab_sel["instrument"].iloc[0]],
+                                         filter=[tab_sel["filter"].iloc[0]],
+                                         )).set_index(["objectid", "label", "filter", "mission"])
+            df_spec.append(dfsingle)
+
+            # Quick plot
+            if quickplot:
+                tmp = np.percentile(fluxes_stack, q=(1, 50, 99))
+                plt.plot(wave_grid, fluxes_stack)
+                plt.ylim(tmp[0], tmp[2])
+                plt.xlabel(r"Observed Wavelength [$\mu$m]")
+                plt.ylabel(r"Flux [Jy]")
+                plt.show()
 
     return df_spec
 
@@ -332,79 +333,78 @@ def HST_get_spec(sample_table, search_radius_arcsec, datadir, verbose,
                                                     )
         print("Number of search results: {}".format(len(query_results)))
 
-        if len(query_results) > 0:  # found some spectra
-
-            # Retrieve spectra
-            data_products_list = Observations.get_product_list(query_results)
-
-            # Filter
-            data_products_list_filter = Observations.filter_products(data_products_list,
-                                                                     productType=["SCIENCE"],
-                                                                     extension="fits",
-                                                                     # only fully reduced or contributed
-                                                                     calib_level=[3, 4],
-                                                                     productSubGroupDescription=[
-                                                                         "SX1"]  # only 1D spectra
-                                                                     )
-            print("Number of files to download: {}".format(len(data_products_list_filter)))
-
-            if len(data_products_list_filter) > 0:
-
-                # Download
-                trap = io.StringIO()
-                with redirect_stdout(trap):
-                    download_results = Observations.download_products(
-                        data_products_list_filter, download_dir=this_data_dir)
-                if verbose:
-                    print(trap.getvalue())
-
-                # Create table
-                # NOTE: `download_results` has NOT the same order as `data_products_list_filter`.
-                # We therefore have to "manually" get the product file names here and then use
-                # those to open the files.
-                keys = ["filters", "obs_collection", "instrument_name", "calib_level",
-                        "t_obs_release", "proposal_id", "obsid", "objID", "distance"]
-                tab = Table(names=keys + ["productFilename"], dtype=[str,
-                            str, str, int, float, int, int, int, float]+[str])
-                for jj in range(len(data_products_list_filter)):
-                    idx_cross = np.where(query_results["obsid"] ==
-                                         data_products_list_filter["obsID"][jj])[0]
-                    tmp = query_results[idx_cross][keys]
-                    tab.add_row(list(tmp[0]) + [data_products_list_filter["productFilename"][jj]])
-
-                # Create multi-index object
-                for jj in range(len(tab)):
-
-                    # find correct path name:
-                    # Note that `download_results` does NOT have same order as `tab`!!
-                    file_idx = np.where([tab["productFilename"][jj] in download_results["Local Path"][iii]
-                                        for iii in range(len(download_results))])[0]
-
-                    # open spectrum
-                    filepath = download_results["Local Path"][file_idx[0]]
-                    # print(filepath)
-                    spec1d = Spectrum1D.read(filepath)
-
-                    # Note: this should be in erg/s/cm2/A and any wavelength unit.
-                    dfsingle = pd.DataFrame(dict(
-                        wave=[spec1d.spectral_axis], flux=[spec1d.flux], err=[
-                            spec1d.uncertainty.array * spec1d.uncertainty.unit],
-                        label=[stab["label"]],
-                        objectid=[stab["objectid"]],
-                        # objID=[tab["objID"][jj]],
-                        # obsid=[tab["obsid"][jj]],
-                        mission=[tab["obs_collection"][jj]],
-                        instrument=[tab["instrument_name"][jj]],
-                        filter=[tab["filters"][jj]],
-                    )).set_index(["objectid", "label", "filter", "mission"])
-                    df_spec.append(dfsingle)
-
-                if delete_downloaded_data:
-                    shutil.rmtree(this_data_dir)
-
-            else:
-                print("Nothing to download for source {}.".format(stab["label"]))
-        else:
+        if len(query_results) == 0:
             print("Source {} could not be found".format(stab["label"]))
+            continue
+
+        # Retrieve spectra
+        data_products_list = Observations.get_product_list(query_results)
+
+        # Filter
+        data_products_list_filter = Observations.filter_products(data_products_list,
+                                                                 productType=["SCIENCE"],
+                                                                 extension="fits",
+                                                                 # only fully reduced or contributed
+                                                                 calib_level=[3, 4],
+                                                                 productSubGroupDescription=[
+                                                                     "SX1"]  # only 1D spectra
+                                                                 )
+        print("Number of files to download: {}".format(len(data_products_list_filter)))
+
+        if len(data_products_list_filter) == 0:
+            print("Nothing to download for source {}.".format(stab["label"]))
+            continue
+
+        # Download
+        trap = io.StringIO()
+        with redirect_stdout(trap):
+            download_results = Observations.download_products(
+                data_products_list_filter, download_dir=this_data_dir)
+        if verbose:
+            print(trap.getvalue())
+
+        # Create table
+        # NOTE: `download_results` has NOT the same order as `data_products_list_filter`.
+        # We therefore have to "manually" get the product file names here and then use
+        # those to open the files.
+        keys = ["filters", "obs_collection", "instrument_name", "calib_level",
+                "t_obs_release", "proposal_id", "obsid", "objID", "distance"]
+        tab = Table(names=keys + ["productFilename"], dtype=[str,
+                    str, str, int, float, int, int, int, float]+[str])
+        for jj in range(len(data_products_list_filter)):
+            idx_cross = np.where(query_results["obsid"] ==
+                                 data_products_list_filter["obsID"][jj])[0]
+            tmp = query_results[idx_cross][keys]
+            tab.add_row(list(tmp[0]) + [data_products_list_filter["productFilename"][jj]])
+
+        # Create multi-index object
+        for jj in range(len(tab)):
+
+            # find correct path name:
+            # Note that `download_results` does NOT have same order as `tab`!!
+            file_idx = np.where([tab["productFilename"][jj] in download_results["Local Path"][iii]
+                                for iii in range(len(download_results))])[0]
+
+            # open spectrum
+            filepath = download_results["Local Path"][file_idx[0]]
+            # print(filepath)
+            spec1d = Spectrum1D.read(filepath)
+
+            # Note: this should be in erg/s/cm2/A and any wavelength unit.
+            dfsingle = pd.DataFrame(dict(
+                wave=[spec1d.spectral_axis], flux=[spec1d.flux], err=[
+                    spec1d.uncertainty.array * spec1d.uncertainty.unit],
+                label=[stab["label"]],
+                objectid=[stab["objectid"]],
+                # objID=[tab["objID"][jj]],
+                # obsid=[tab["obsid"][jj]],
+                mission=[tab["obs_collection"][jj]],
+                instrument=[tab["instrument_name"][jj]],
+                filter=[tab["filters"][jj]],
+            )).set_index(["objectid", "label", "filter", "mission"])
+            df_spec.append(dfsingle)
+
+        if delete_downloaded_data:
+            shutil.rmtree(this_data_dir)
 
     return df_spec

--- a/spectroscopy/code_src/sdss_functions.py
+++ b/spectroscopy/code_src/sdss_functions.py
@@ -37,26 +37,26 @@ def SDSS_get_spec(sample_table, search_radius_arcsec, data_release):
         xid = SDSS.query_region(search_coords, radius=search_radius_arcsec *
                                 u.arcsec, spectro=True, data_release=data_release)
 
-        if str(type(xid)) != "<class 'NoneType'>":
-            sp = SDSS.get_spectra(matches=xid, show_progress=True, data_release=data_release)
-
-            # Get data
-            # only one entry because we only search for one xid at a time. Could change that?
-            wave = 10**sp[0]["COADD"].data.loglam * u.angstrom
-            flux = sp[0]["COADD"].data.flux*1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
-            err = np.sqrt(1/sp[0]["COADD"].data.ivar)*1e-17 * flux.unit
-
-            # Add to df_spec.
-            dfsingle = pd.DataFrame(dict(wave=[wave], flux=[flux], err=[err],
-                                         label=[stab["label"]],
-                                         objectid=[stab["objectid"]],
-                                         mission=["SDSS"],
-                                         instrument=["SDSS"],
-                                         filter=["optical"],
-                                         )).set_index(["objectid", "label", "filter", "mission"])
-            df_spec.append(dfsingle)
-
-        else:
+        if str(type(xid)) == "<class 'NoneType'>":
             print("Source {} could not be found".format(stab["label"]))
+            continue
+
+        sp = SDSS.get_spectra(matches=xid, show_progress=True, data_release=data_release)
+
+        # Get data
+        # only one entry because we only search for one xid at a time. Could change that?
+        wave = 10**sp[0]["COADD"].data.loglam * u.angstrom
+        flux = sp[0]["COADD"].data.flux*1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
+        err = np.sqrt(1/sp[0]["COADD"].data.ivar)*1e-17 * flux.unit
+
+        # Add to df_spec.
+        dfsingle = pd.DataFrame(dict(wave=[wave], flux=[flux], err=[err],
+                                     label=[stab["label"]],
+                                     objectid=[stab["objectid"]],
+                                     mission=["SDSS"],
+                                     instrument=["SDSS"],
+                                     filter=["optical"],
+                                     )).set_index(["objectid", "label", "filter", "mission"])
+        df_spec.append(dfsingle)
 
     return df_spec

--- a/spectroscopy/code_src/spitzer_functions.py
+++ b/spectroscopy/code_src/spitzer_functions.py
@@ -42,65 +42,66 @@ def SpitzerIRS_get_spec(sample_table, search_radius_arcsec, COMBINESPEC):
                                 spatial="Cone", radius=search_radius_arcsec * u.arcsec)
         print("Number of entries found: {}".format(len(tab)))
 
-        if len(tab) > 0:  # found a source
+        if len(tab) == 0:
+            continue
 
-            # If multiple entries are found, pick the closest.
-            # Or should we take the average instead??
-            if len(tab) > 0:
-                print("More than 1 entry found", end="")
-                if not COMBINESPEC:
-                    print(" - pick the closest")
-                    sep = [search_coords.separation(SkyCoord(tt["ra"], tt["dec"], unit=u.deg, frame='icrs')).to(
-                        u.arcsecond).value for tt in tab]
-                    id_min = np.where(sep == np.nanmin(sep))[0]
-                    tab_final = tab[id_min]
-                else:
-                    print(" - Combine spectra")
-                    tab_final = tab.copy()
+        # If multiple entries are found, pick the closest.
+        # Or should we take the average instead??
+        if len(tab) > 0:
+            print("More than 1 entry found", end="")
+            if not COMBINESPEC:
+                print(" - pick the closest")
+                sep = [search_coords.separation(SkyCoord(tt["ra"], tt["dec"], unit=u.deg, frame='icrs')).to(
+                    u.arcsecond).value for tt in tab]
+                id_min = np.where(sep == np.nanmin(sep))[0]
+                tab_final = tab[id_min]
             else:
+                print(" - Combine spectra")
                 tab_final = tab.copy()
+        else:
+            tab_final = tab.copy()
 
-            # Now extract spectra and put all in one array
-            specs = []
-            for tt in tab:
-                url = "https://irsa.ipac.caltech.edu{}".format(tt["xtable"].split("\"")[1])
-                spec = Table.read(url, format="ipac")  # flux_density in Jy
-                specs.append(spec)
+        # Now extract spectra and put all in one array
+        specs = []
+        for tt in tab:
+            url = "https://irsa.ipac.caltech.edu{}".format(tt["xtable"].split("\"")[1])
+            spec = Table.read(url, format="ipac")  # flux_density in Jy
+            specs.append(spec)
 
-            # Create final spectrum (combine if necesary)
-            # Note that spectrum is automatically combined if longer than length=1
-            lengths = np.asarray([len(spec["wavelength"])
-                                 for spec in specs])  # get the lengths of the spectra
-            # pick the spectra with the most wavelength as template
-            id_orig = np.where(lengths == np.nanmax(lengths))[0]
-            if len(id_orig) > 0:
-                id_orig = id_orig[0]
-            wave_orig = np.asarray(specs[id_orig]["wavelength"])  # original wavelength
-            fluxes = np.asarray([np.interp(wave_orig, spec["wavelength"],
-                                spec["flux_density"]) for spec in specs])
-            errors = np.asarray(
-                [np.interp(wave_orig, spec["wavelength"], spec["error"]) for spec in specs])
-            flux_jy_mean = np.nanmean(fluxes, axis=0)
-            errors_jy_combined = np.asarray(
-                [np.sqrt(np.nansum(errors[:, ii]**2)) for ii in range(errors.shape[1])])
+        # Create final spectrum (combine if necesary)
+        # Note that spectrum is automatically combined if longer than length=1
+        lengths = np.asarray([len(spec["wavelength"])
+                              for spec in specs])  # get the lengths of the spectra
+        # pick the spectra with the most wavelength as template
+        id_orig = np.where(lengths == np.nanmax(lengths))[0]
+        if len(id_orig) > 0:
+            id_orig = id_orig[0]
+        wave_orig = np.asarray(specs[id_orig]["wavelength"])  # original wavelength
+        fluxes = np.asarray([np.interp(wave_orig, spec["wavelength"],
+                            spec["flux_density"]) for spec in specs])
+        errors = np.asarray(
+            [np.interp(wave_orig, spec["wavelength"], spec["error"]) for spec in specs])
+        flux_jy_mean = np.nanmean(fluxes, axis=0)
+        errors_jy_combined = np.asarray(
+            [np.sqrt(np.nansum(errors[:, ii]**2)) for ii in range(errors.shape[1])])
 
-            # Change units
-            wave_orig_A = (wave_orig*u.micrometer).to(u.angstrom)
-            flux_cgs_mean = (flux_jy_mean*u.jansky).to(u.erg/u.second/u.centimeter **
-                                                       2/u.hertz) * const.c.to(u.angstrom/u.second) / (wave_orig_A**2)
-            errors_cgs_combined = (errors_jy_combined*u.jansky).to(u.erg/u.second /
-                                                                   u.centimeter**2/u.hertz) * const.c.to(u.angstrom/u.second) / (wave_orig_A**2)
+        # Change units
+        wave_orig_A = (wave_orig*u.micrometer).to(u.angstrom)
+        flux_cgs_mean = (flux_jy_mean*u.jansky).to(u.erg/u.second/u.centimeter **
+                                                   2/u.hertz) * const.c.to(u.angstrom/u.second) / (wave_orig_A**2)
+        errors_cgs_combined = (errors_jy_combined*u.jansky).to(u.erg/u.second /
+                                                               u.centimeter**2/u.hertz) * const.c.to(u.angstrom/u.second) / (wave_orig_A**2)
 
-            # Create MultiIndex object
-            dfsingle = pd.DataFrame(dict(wave=[wave_orig_A],
-                                         flux=[flux_cgs_mean],
-                                         err=[errors_cgs_combined],
-                                         label=[stab["label"]],
-                                         objectid=[stab["objectid"]],
-                                         mission=["Spitzer"],
-                                         instrument=["IRS"],
-                                         filter=["IR"],
-                                         )).set_index(["objectid", "label", "filter", "mission"])
-            df_spec.append(dfsingle)
+        # Create MultiIndex object
+        dfsingle = pd.DataFrame(dict(wave=[wave_orig_A],
+                                     flux=[flux_cgs_mean],
+                                     err=[errors_cgs_combined],
+                                     label=[stab["label"]],
+                                     objectid=[stab["objectid"]],
+                                     mission=["Spitzer"],
+                                     instrument=["IRS"],
+                                     filter=["IR"],
+                                     )).set_index(["objectid", "label", "filter", "mission"])
+        df_spec.append(dfsingle)
 
     return df_spec


### PR DESCRIPTION
Some of the spectroscopy functions have quite a few levels of indentation (almost 10 in some cases) due to nested `for` loops and `if` statements. This tends to squish the code into a narrow region on the right making it more difficult to read. This PR reduces some of the indentation by inverting the conditions of `if` statements where possible.

Simple example with just 2 levels (benefits are greater when there are more levels). This:
```python
for sample in sample_table:
    table = query_archive(...)
    if len(table) > 0:
        # long block of code
        # ...
    else:
        print("no results found")
```

becomes this:
```python
for sample in sample_table:
    table = query_archive(...)
    if len(table) == 0:
        print("no results found")
        continue
    # long block of code. now has more room horizontally.
    # ...
```

