### PR TITLE
Deal with warnings

### DIFF
--- a/spectroscopy/code_src/keck_functions.py
+++ b/spectroscopy/code_src/keck_functions.py
@@ -64,6 +64,7 @@ def KeckDEIMOS_get_spec(sample_table, search_radius_arcsec):
         # Prepare arrays
         wave = spec["LAMBDA"][0] * u.angstrom
         flux_cgs = spec["FLUX"][0] * 1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
+        # [FIXME] Next line raises 'RuntimeWarning: divide by zero encountered in divide'
         error_cgs = np.sqrt(1 / spec["IVAR"][0]) * 1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
 
         # Create MultiIndex object

--- a/spectroscopy/code_src/keck_functions.py
+++ b/spectroscopy/code_src/keck_functions.py
@@ -64,8 +64,10 @@ def KeckDEIMOS_get_spec(sample_table, search_radius_arcsec):
         # Prepare arrays
         wave = spec["LAMBDA"][0] * u.angstrom
         flux_cgs = spec["FLUX"][0] * 1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
-        # [FIXME] Next line raises 'RuntimeWarning: divide by zero encountered in divide'
-        error_cgs = np.sqrt(1 / spec["IVAR"][0]) * 1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
+        # Inverse variances may be zero, resulting in infinite error.
+        # We'll leave these in and ignore the "divide by zero" warning.
+        with np.errstate(divide='ignore'):
+            error_cgs = np.sqrt(1 / spec["IVAR"][0]) * flux_cgs.unit
 
         # Create MultiIndex object
         dfsingle = pd.DataFrame(dict(wave=[wave],

--- a/spectroscopy/code_src/mast_functions.py
+++ b/spectroscopy/code_src/mast_functions.py
@@ -1,10 +1,12 @@
 import io
 import os
 import shutil
+import warnings
 from contextlib import redirect_stdout
 
 import astropy.constants as const
 import astropy.units as u
+import astroquery.exceptions
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -96,8 +98,11 @@ def JWST_get_spec_helper(sample_table, search_radius_arcsec, datadir, verbose,
 
         # Query results
         search_coords = stab["coord"]
-        # [FIXME] Next code line raises a warning when stab['label'] == 'NGC3049'.
-        # 'WARNING: NoResultsWarning: Query returned no results. [astroquery.mast.discovery_portal]'
+        # If no results are found, this will raise a warning. We explicitly handle the no-results
+        # case below, so let's suppress the warning to avoid confusing notebook users.
+        warnings.filterwarnings("ignore", message='Query returned no results.',
+                                category=astroquery.exceptions.NoResultsWarning,
+                                module="astroquery.mast.discovery_portal")
         query_results = Observations.query_criteria(
             coordinates=search_coords, radius=search_radius_arcsec * u.arcsec,
             dataproduct_type=["spectrum"], obs_collection=["JWST"], intentType="science",
@@ -313,8 +318,11 @@ def HST_get_spec(sample_table, search_radius_arcsec, datadir, verbose,
 
         # Query results
         search_coords = stab["coord"]
-        # [FIXME] Next code line raises a warning when stab['label'] == 'Arp220'.
-        # 'WARNING: NoResultsWarning: Query returned no results. [astroquery.mast.discovery_portal]'
+        # If no results are found, this will raise a warning. We explicitly handle the no-results
+        # case below, so let's suppress the warning to avoid confusing notebook users.
+        warnings.filterwarnings("ignore", message='Query returned no results.',
+                                category=astroquery.exceptions.NoResultsWarning,
+                                module="astroquery.mast.discovery_portal")
         query_results = Observations.query_criteria(
             coordinates=search_coords, radius=search_radius_arcsec * u.arcsec,
             dataproduct_type=["spectrum"], obs_collection=["HST"], intentType="science",

--- a/spectroscopy/code_src/mast_functions.py
+++ b/spectroscopy/code_src/mast_functions.py
@@ -96,6 +96,8 @@ def JWST_get_spec_helper(sample_table, search_radius_arcsec, datadir, verbose,
 
         # Query results
         search_coords = stab["coord"]
+        # [FIXME] Next code line raises a warning when stab['label'] == 'NGC3049'.
+        # 'WARNING: NoResultsWarning: Query returned no results. [astroquery.mast.discovery_portal]'
         query_results = Observations.query_criteria(
             coordinates=search_coords, radius=search_radius_arcsec * u.arcsec,
             dataproduct_type=["spectrum"], obs_collection=["JWST"], intentType="science",
@@ -311,6 +313,8 @@ def HST_get_spec(sample_table, search_radius_arcsec, datadir, verbose,
 
         # Query results
         search_coords = stab["coord"]
+        # [FIXME] Next code line raises a warning when stab['label'] == 'Arp220'.
+        # 'WARNING: NoResultsWarning: Query returned no results. [astroquery.mast.discovery_portal]'
         query_results = Observations.query_criteria(
             coordinates=search_coords, radius=search_radius_arcsec * u.arcsec,
             dataproduct_type=["spectrum"], obs_collection=["HST"], intentType="science",
@@ -336,6 +340,9 @@ def HST_get_spec(sample_table, search_radius_arcsec, datadir, verbose,
             continue
 
         # Download
+        # Observations.download_products prints an info message for every download, like:
+        #   "Downloading URL https://mast... to ./data/... ... [Done]"
+        # Suppress these by redirecting stdout to a trap.
         trap = io.StringIO()
         with redirect_stdout(trap):
             download_results = Observations.download_products(

--- a/spectroscopy/code_src/mast_functions.py
+++ b/spectroscopy/code_src/mast_functions.py
@@ -1,8 +1,6 @@
-import io
 import os
 import shutil
 import warnings
-from contextlib import redirect_stdout
 
 import astropy.constants as const
 import astropy.units as u
@@ -129,13 +127,9 @@ def JWST_get_spec_helper(sample_table, search_radius_arcsec, datadir, verbose,
             print("Nothing to download for source {}.".format(stab["label"]))
             continue
 
-        # Download (suppress output)
-        trap = io.StringIO()
-        with redirect_stdout(trap):
-            download_results = Observations.download_products(
-                data_products_list_filter, download_dir=this_data_dir)
-        if verbose:
-            print(trap.getvalue())
+        # Download
+        download_results = Observations.download_products(
+            data_products_list_filter, download_dir=this_data_dir, verbose=False)
 
         # Create table
         # NOTE: `download_results` has NOT the same order as `data_products_list_filter`.
@@ -348,15 +342,8 @@ def HST_get_spec(sample_table, search_radius_arcsec, datadir, verbose,
             continue
 
         # Download
-        # Observations.download_products prints an info message for every download, like:
-        #   "Downloading URL https://mast... to ./data/... ... [Done]"
-        # Suppress these by redirecting stdout to a trap.
-        trap = io.StringIO()
-        with redirect_stdout(trap):
-            download_results = Observations.download_products(
-                data_products_list_filter, download_dir=this_data_dir)
-        if verbose:
-            print(trap.getvalue())
+        download_results = Observations.download_products(
+            data_products_list_filter, download_dir=this_data_dir, verbose=False)
 
         # Create table
         # NOTE: `download_results` has NOT the same order as `data_products_list_filter`.

--- a/spectroscopy/code_src/sdss_functions.py
+++ b/spectroscopy/code_src/sdss_functions.py
@@ -47,8 +47,10 @@ def SDSS_get_spec(sample_table, search_radius_arcsec, data_release):
         # only one entry because we only search for one xid at a time. Could change that?
         wave = 10**sp[0]["COADD"].data.loglam * u.angstrom
         flux = sp[0]["COADD"].data.flux*1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
-        # [FIXME] Next line raises 'RuntimeWarning: divide by zero encountered in divide'
-        err = np.sqrt(1/sp[0]["COADD"].data.ivar)*1e-17 * flux.unit
+        # Inverse variances may be zero, resulting in infinite error.
+        # We'll leave these in and ignore the "divide by zero" warning.
+        with np.errstate(divide='ignore'):
+            err = np.sqrt(1/sp[0]["COADD"].data.ivar)*1e-17 * flux.unit
 
         # Add to df_spec.
         dfsingle = pd.DataFrame(dict(wave=[wave], flux=[flux], err=[err],

--- a/spectroscopy/code_src/sdss_functions.py
+++ b/spectroscopy/code_src/sdss_functions.py
@@ -47,6 +47,7 @@ def SDSS_get_spec(sample_table, search_radius_arcsec, data_release):
         # only one entry because we only search for one xid at a time. Could change that?
         wave = 10**sp[0]["COADD"].data.loglam * u.angstrom
         flux = sp[0]["COADD"].data.flux*1e-17 * u.erg/u.second/u.centimeter**2/u.angstrom
+        # [FIXME] Next line raises 'RuntimeWarning: divide by zero encountered in divide'
         err = np.sqrt(1/sp[0]["COADD"].data.ivar)*1e-17 * flux.unit
 
         # Add to df_spec.

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -109,6 +109,7 @@ This cell will install them if needed:
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
 # !pip install -r requirements_spectra_generator.txt
+# !pip install --upgrade --pre astroquery  # >=0.4.8.dev9474 needed for mast_functions
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Clean up warnings in the spectra_generator notebook:

- [x] MAST: `NoResultsWarning` -- Suppress these since we don't expect all-sky coverage and we explicitly handle the no-results cases.
- [x] Keck and SDSS: `RuntimeWarning: divide by zero` -- These occur in error calculations when the inverse variance is zero, resulting in infinite error. Leave this bad data in and ignore the warning.