### PR TITLE
change order, add jupytext command

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,3 +28,6 @@ forced_photometry/README
 light_curves/README
 ```
 
+Note that we store these notebooks as markdown files.  In the Fornax Science Console, these should open automatically in the runnable jupyter notebook format.  If they do not, or you run them elsewhere, you may need to convert them explicitly with 
+
+`jupytext --to notebook yourfile.md`

--- a/index.md
+++ b/index.md
@@ -4,6 +4,18 @@ NASA Astrophysics is developing the Fornax Initiative, a cloud-based system that
 brings together data, software, and computing so that researchers can focus on science.
 
 
+## User Documentation
+
+```{toctree}
+---
+maxdepth: 2
+caption: User Documentation
+---
+
+documentation/README
+
+```
+
 ## Tutorial Notebooks
 
 ```{toctree}
@@ -16,15 +28,3 @@ forced_photometry/README
 light_curves/README
 ```
 
-
-## User Documentation
-
-```{toctree}
----
-maxdepth: 2
-caption: User Documentation
----
-
-documentation/README
-
-```


### PR DESCRIPTION
Personally I think the User Docs for Fornax should come first.  Otherwise people launch into the notebooks without knowing anything about how to use the platform.

Also added the jupytext command.  