### PR TITLE
removing drop_empty_siblings parameter from lsdb.from_dataframe

### DIFF
--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -62,7 +62,8 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
         dec_column="dec_deg", 
         margin_threshold=10,
         # Optimize partition size
-        drop_empty_siblings=True
+        #drop_empty_siblings=True
+        #this parameter appears to be deprecated 2/26/25
     )
 
     #plan to cross match panstarrs object with my sample 


### PR DESCRIPTION
simple fix to issue #376 .  The lsdb documentation says that this parameter exists, so I have opened an issue over there to ask them to clarify their documentation, and commented out this line for now in our code. 

This is somewhat pointless, because making this fix then allows me to run the code and realize that the panstarrs module doesn't work at all anymore because hipscat is apparently not a thing anymore.  I will open a new issue for that.