### PR TITLE
converting panstarrs read_hipscat to read_hats

### DIFF
--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -26,20 +26,25 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
     #read in the panstarrs object table to lsdb
     #this table will be used for cross matching with our sample's ra and decs
     #but does not have light curve information
-    panstarrs_object = lsdb.read_hats(UPath('s3://stpubdata/panstarrs/ps1/public/hats/otmo', anon=True),    margin_cache=UPath('s3://stpubdata/panstarrs/ps1/public/hats/otmo_10arcs', anon=True),  columns=[ "objID",  # PS1 ID
+    panstarrs_object = lsdb.read_hats(
+        UPath('s3://stpubdata/panstarrs/ps1/public/hats/otmo', anon=True), 
+        margin_cache=UPath('s3://stpubdata/panstarrs/ps1/public/hats/otmo_10arcs', anon=True),
+        columns=[ "objID",  # PS1 ID
                 "raMean", "decMean",  # coordinates to use for cross-matching
                 "nStackDetections",  # some other data to use
                 ]
-                      )
+        )
     #read in the panstarrs light curves to lsdb
     #panstarrs recommendation is not to index into this table with ra and dec
     #but to use object ids from the above object table
-    panstarrs_detect = lsdb.read_hats(UPath('s3://stpubdata/panstarrs/ps1/public/hats/detection', anon=True), margin_cache=UPath('s3://stpubdata/panstarrs/ps1/public/hats/detection_10arcs', anon=True),
-                      columns=[ "objID",  # PS1 object ID
-            "detectID",  # PS1 detection ID
-            # light-curve stuff
-            "obsTime", "filterID", "psfFlux", "psfFluxErr",
-        ]
+    panstarrs_detect = lsdb.read_hats(
+        UPath('s3://stpubdata/panstarrs/ps1/public/hats/detection', anon=True), 
+        margin_cache=UPath('s3://stpubdata/panstarrs/ps1/public/hats/detection_10arcs', anon=True),
+        columns=[ "objID",  # PS1 object ID
+                "detectID",  # PS1 detection ID
+                # light-curve stuff
+                "obsTime", "filterID", "psfFlux", "psfFluxErr",
+                ]
         )
     #convert astropy table to pandas dataframe
     #special care for the SkyCoords in the table

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -6,9 +6,9 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.4
 kernelspec:
-  display_name: science_demo
+  display_name: notebook
   language: python
-  name: conda-env-science_demo-py
+  name: python3
 ---
 
 # Make Multi-Wavelength Light Curves Using Archival Data
@@ -74,7 +74,7 @@ This cell will install them if needed:
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-# !pip install -r requirements_light_curve_generator.txt
+!pip install -r requirements_light_curve_generator.txt
 ```
 
 ```{code-cell} ipython3
@@ -257,6 +257,8 @@ print('WISE search took:', time.time() - WISEstarttime, 's')
 
 ### 2.4 MAST: Pan-STARRS
 The function to retrieve lightcurves from Pan-STARRS uses a version of both the object and light curve catalogs that are stored in the cloud and accessed using [lsdb](https://docs.lsdb.io/en/stable/).  This function is efficient at large scale (sample sizes > ~1000).
+
+Some warnings are expected.
 
 ```{code-cell} ipython3
 panstarrsstarttime = time.time()
@@ -452,3 +454,7 @@ This work made use of:
 * Lightkurve; Lightkurve Collaboration 2018, 2018ascl.soft12013L
 * acstools; https://zenodo.org/record/7406933#.ZBH1HS-B0eY
 * unWISE light curves; Meisner et al., 2023, 2023AJ....165...36M
+
+```{code-cell} ipython3
+
+```

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -74,7 +74,7 @@ This cell will install them if needed:
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-!pip install -r requirements_light_curve_generator.txt
+#!pip install -r requirements_light_curve_generator.txt
 ```
 
 ```{code-cell} ipython3
@@ -101,7 +101,7 @@ from tess_kepler_functions import tess_kepler_get_lightcurves
 from wise_functions import wise_get_lightcurves
 # Note: ZTF data is temporarily located in a non-public AWS S3 bucket. It is automatically available
 # from the Fornax Science Console, but otherwise will require explicit user credentials.
-from ztf_functions import ztf_get_lightcurves
+# from ztf_functions import ztf_get_lightcurves
 ```
 
 ## 1. Define the sample

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -454,7 +454,3 @@ This work made use of:
 * Lightkurve; Lightkurve Collaboration 2018, 2018ascl.soft12013L
 * acstools; https://zenodo.org/record/7406933#.ZBH1HS-B0eY
 * unWISE light curves; Meisner et al., 2023, 2023AJ....165...36M
-
-```{code-cell} ipython3
-
-```

--- a/light_curves/requirements_light_curve_generator.txt
+++ b/light_curves/requirements_light_curve_generator.txt
@@ -14,7 +14,8 @@ astroquery>=0.4.8.dev0
 acstools
 lightkurve
 alerce
-lsdb==0.4.5
+lsdb>=0.4.5
+universal_pathlib
 # We use distributed in this notebook, but installing any dask would make the [dataframe] extras required by dependencies for other notebooks. 
 # It feels to be the cleanest solution to add the dependency here as we don't directly use it elsewhere. 
 dask[distributed,dataframe]

--- a/light_curves/requirements_light_curve_generator.txt
+++ b/light_curves/requirements_light_curve_generator.txt
@@ -14,7 +14,7 @@ astroquery>=0.4.8.dev0
 acstools
 lightkurve
 alerce
-lsdb
+lsdb==0.4.5
 # We use distributed in this notebook, but installing any dask would make the [dataframe] extras required by dependencies for other notebooks. 
 # It feels to be the cleanest solution to add the dependency here as we don't directly use it elsewhere. 
 dask[distributed,dataframe]


### PR DESCRIPTION
panstarrs module in light_curve_generator was broken maybe because read_hipscat is gone, or the hipscat files themselves were gone.  So, the switch to hats format is in this PR.

I mostly just changed lsdb.read_hipscat to lsdb.read_hats.  Some warnings pop up now in this panstarrs module, so I have added a line of text to warn people that the warnings are expected.

This closes #380 

This also closes #376