### PR TITLE
hats light curves

### DIFF
--- a/light_curves/code_src/hats_functions.py
+++ b/light_curves/code_src/hats_functions.py
@@ -1,0 +1,133 @@
+import numpy as np
+import pandas as pd
+from astropy.table import Table
+import lsdb
+from dask.distributed import Client
+from data_structures import MultiIndexDFObject
+from upath import UPath
+
+def hats_get_lightcurves(
+    sample_table: Table,
+    object_catalog_path: str,
+    lightcurve_catalog_path: str,
+    object_columns: list[str],
+    light_curve_columns: list[str],
+    filter_id_to_name: dict[int, str],
+    id_col: str,
+    time_col: str,
+    flux_col: str,
+    err_col: str,
+    *,
+    radius: float = 1.0,
+    object_margin_cache=None,
+    lightcurve_margin_cache=None,
+) -> MultiIndexDFObject:
+    """
+    Generic LSDB/HATs light-curve fetcher by cross-matching an object catalog
+    to an input coord list, then joining to a light-curve catalog.
+
+    Parameters
+    ----------
+    sample_table : astropy.table.Table
+        Table with columns ['objectid', 'coord', 'label'] (SkyCoord in 'coord').
+    object_catalog_path : str
+        S3/HATs path to the **object** catalog (used for cross-matching).
+    lightcurve_catalog_path : str
+        S3/HATs path to the **light curve** catalog.
+    object_columns : list of str
+        Columns to read from the object catalog (must include `id_col`, ra/dec).
+    detect_columns : list of str
+        Columns to read from the light-curve catalog (must include `id_col`,
+        `time_col`, `flux_col`, `err_col`, plus the filter-ID column).
+    filter_id_to_name : dict
+        Mapping from integer filter IDs to human-readable band names.
+    id_col : str
+        Name of the object-ID column in both catalogs.
+    time_col : str
+        Name of the time/MJD column in the light-curve catalog.
+    flux_col : str
+        Name of the flux column in the light-curve catalog.
+    err_col : str
+        Name of the flux-uncertainty column in the light-curve catalog.
+    radius : float, optional
+        Cross-match radius in arcseconds (default 1.0).
+
+    Returns
+    -------
+    MultiIndexDFObject
+        A multi-indexed (objectid, label, band, time) container of the light curves.
+    """
+    # 1) read the two catalogs lazily
+    
+    # this table will be used for cross matching with our sample's ra and decs
+    # but does not have light curve information
+    obj_cat = lsdb.read_hats(object_catalog_path,
+                             columns=object_columns,
+                             margin_cache=object_margin_cache)
+    # this table houses the light curves
+    lc_cat  = lsdb.read_hats(lightcurve_catalog_path,
+                             columns=light_curve_columns,
+                            margin_cache=lightcurve_margin_cache)
+    
+    # 2) convert astropy sample_table into an LSDB catalog
+    sample_df = pd.DataFrame({
+        'objectid': sample_table['objectid'],
+        'ra_deg':    sample_table['coord'].ra.deg,
+        'dec_deg':   sample_table['coord'].dec.deg,
+        'label':     sample_table['label']
+    })
+    # convert dataframe to hats catalog
+    sample_lsdb = lsdb.from_dataframe(
+        sample_df,
+        ra_column='ra_deg',
+        dec_column='dec_deg',
+        margin_threshold=10,
+        drop_empty_siblings=True
+    )
+
+    # 3) cross-match to find nearest object
+    # only keep the best match
+    matched_obj = obj_cat.crossmatch(
+        sample_lsdb,
+        radius_arcsec=radius,
+        n_neighbors=1,
+        suffixes=("", "")     # ← prevent “objID” → “objID_1”
+    )
+
+    # 4) join to the light-curve catalog
+    matched_lc = matched_obj.join(
+        lc_cat,
+        left_on=id_col,
+        right_on=id_col,
+        output_catalog_name=f"{id_col}_lc",
+        suffixes=["", ""]
+    )
+
+    # 5) compute on Dask
+    # here is where the actual work gets done
+    with Client():
+        matched_df = matched_lc.compute()
+
+    # 6) handle no matches
+    if matched_df.empty:
+        return MultiIndexDFObject(data=pd.DataFrame())
+
+    # 7) map filter IDs to names
+    filter_col = next(c for c in light_curve_columns if 'filter' in c.lower())
+    band_names = np.vectorize(filter_id_to_name.get)(matched_df[filter_col])
+
+    # 8) build and index the DataFrame
+    df_lc = pd.DataFrame({
+        'flux':     pd.to_numeric(matched_df[flux_col], errors='coerce'),
+        'err':      pd.to_numeric(matched_df[err_col],  errors='coerce'),
+        'time':     pd.to_numeric(matched_df[time_col], errors='coerce'),
+        'objectid': matched_df['objectid'].astype(np.int64),
+        'band':     band_names,
+        'label':    matched_df['label'].astype(str)
+    })
+    
+    df = pd.DataFrame(df_lc).set_index(['objectid', 'label', 'band', 'time'])
+    
+    return MultiIndexDFObject(data=df)
+
+

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -5,117 +5,63 @@ import lsdb
 from dask.distributed import Client
 from data_structures import MultiIndexDFObject
 from upath import UPath
+from hats_functions import hats_get_lightcurves
 
-# panstarrs light curves from hipscat catalog in S3 using lsdb
 
-
-def panstarrs_get_lightcurves(sample_table, *, radius=1):
-    """Searches panstarrs hipscat files for light curves from a list of input coordinates.
-
+def panstarrs_hats_get_lightcurves(sample_table: Table, *, radius: float = 1.0):
+    """
+    Searches panstarrs hats files for light curves from a list of input coordinates.  
+    
     Parameters
     ----------
-    sample_table : `~astropy.table.Table`
-        Table with the coordinates and journal reference labels of the sources
-    radius : float
-        search radius, how far from the source should the archives return results
+    sample_table : astropy.table.Table
+        Input table of targets. Must have columns:
+        
+        - ``objectid`` : int or str  
+          Unique identifier for each source.  
+        - ``coord`` : astropy.coordinates.SkyCoord  
+          SkyCoord of each source for cross-matching.  
+        - ``label`` : str  
+          Label to propagate into the output light-curve index.  
+    radius : float, optional
+        Cross-match search radius in arcseconds (default is 1.0).
 
     Returns
     -------
-    df_lc : MultiIndexDFObject
-        the main data structure to store all light curves
+
+    data_structures.MultiIndexDFObject
+        A container whose `.data` is a pandas DataFrame with a MultiIndex
+        (``objectid``, ``label``, ``band``, ``time``) and columns:
+        
+        - ``flux`` : float  
+          PSF flux in mJy (``psfFlux * 1e3``).  
+        - ``err`` : float  
+          PSF flux uncertainty in mJy (``psfFluxErr * 1e3``).
+
+
     """
-
-    # read in the panstarrs object table to lsdb
-    # this table will be used for cross matching with our sample's ra and decs
-    # but does not have light curve information
-    panstarrs_object = lsdb.read_hats(
-        UPath('s3://stpubdata/panstarrs/ps1/public/hats/otmo', anon=True),
-        margin_cache=UPath('s3://stpubdata/panstarrs/ps1/public/hats/otmo_10arcs', anon=True),
-        columns=["objID",  # PS1 ID
-                 "raMean", "decMean",  # coordinates to use for cross-matching
-                 "nStackDetections",  # some other data to use
-                 ]
+    df_lc =  hats_get_lightcurves(
+        sample_table,
+        object_catalog_path='s3://stpubdata/panstarrs/ps1/public/hats/otmo',
+        object_margin_cache='s3://stpubdata/panstarrs/ps1/public/hats/otmo_10arcs',
+        lightcurve_catalog_path='s3://stpubdata/panstarrs/ps1/public/hats/detection',
+        lightcurve_margin_cache='s3://stpubdata/panstarrs/ps1/public/hats/detection_10arcs',
+        object_columns=["objID", "raMean", "decMean", "nStackDetections"],
+        light_curve_columns=["objID", "detectID", "obsTime", "filterID", "psfFlux", "psfFluxErr"],
+        id_col='objID',
+        time_col='obsTime',
+        flux_col='psfFlux',
+        err_col='psfFluxErr',
+        radius=radius,
+        filter_id_to_name={
+            1: 'Pan-STARRS g',
+            2: 'Pan-STARRS r',
+            3: 'Pan-STARRS i',
+            4: 'Pan-STARRS z',
+            5: 'Pan-STARRS y',
+        }
     )
-    # read in the panstarrs light curves to lsdb
-    # panstarrs recommendation is not to index into this table with ra and dec
-    # but to use object ids from the above object table
-    panstarrs_detect = lsdb.read_hats(
-        UPath('s3://stpubdata/panstarrs/ps1/public/hats/detection', anon=True),
-        margin_cache=UPath('s3://stpubdata/panstarrs/ps1/public/hats/detection_10arcs', anon=True),
-        columns=["objID",  # PS1 object ID
-                 "detectID",  # PS1 detection ID
-                 # light-curve stuff
-                 "obsTime", "filterID", "psfFlux", "psfFluxErr",
-                 ]
-    )
-    # convert astropy table to pandas dataframe
-    # special care for the SkyCoords in the table
-    sample_df = pd.DataFrame({'objectid': sample_table['objectid'],
-                              'ra_deg': sample_table['coord'].ra.deg,
-                              'dec_deg': sample_table['coord'].dec.deg,
-                              'label': sample_table['label']})
+    return df_lc
 
-    # convert dataframe to hipscat
-    sample_lsdb = lsdb.from_dataframe(
-        sample_df,
-        ra_column="ra_deg",
-        dec_column="dec_deg",
-        margin_threshold=10,
-        # Optimize partition size
-        drop_empty_siblings=True
-    )
-
-    # plan to cross match panstarrs object with my sample
-    # only keep the best match
-    matched_objects = panstarrs_object.crossmatch(
-        sample_lsdb,
-        radius_arcsec=radius,
-        n_neighbors=1,
-        suffixes=("", "")
-    )
-
-    # plan to join that cross match with detections to get light-curves
-    matched_lc = matched_objects.join(
-        panstarrs_detect,
-        left_on="objID",
-        right_on="objID",
-        output_catalog_name="yang_ps_lc",
-        suffixes=["", ""]
-    )
-
-    # Create default local cluster
-    # here is where the actual work gets done
-    with Client():
-        # compute the cross match with object table
-        # and the join with the detections table
-        matched_df = matched_lc.compute()
-
-    # handle the case where there are no matches and return empty df
-    if len(matched_df["filterID"]) == 0:
-        return MultiIndexDFObject(data=pd.DataFrame())
-
-    # cleanup the filter names to the expected letters
-    filter_id_to_name = {
-        1: 'Pan-STARRS g',
-        2: 'Pan-STARRS r',
-        3: 'Pan-STARRS i',
-        4: 'Pan-STARRS z',
-        5: 'Pan-STARRS y'
-    }
-
-    get_name_from_filter_id = np.vectorize(filter_id_to_name.get)
-    filtername = get_name_from_filter_id(matched_df["filterID"])
-
-    # make the dataframe of light curves
-    # the data conversions are to change from pyarrow datatypes to numpy datatypes
-
-    df_lc = pd.DataFrame({
-        'flux': pd.to_numeric(matched_df['psfFlux'] * 1e3, errors='coerce').astype(np.float64),
-        'err': pd.to_numeric(matched_df['psfFluxErr'] * 1e3, errors='coerce').astype(np.float64),
-        'time': pd.to_numeric(matched_df['obsTime'], errors='coerce').astype(np.float64),
-        'objectid': matched_df['objectid'].astype(np.int64),
-        'band': filtername,
-        'label': matched_df['label'].astype(str)
-    }).set_index(["objectid", "label", "band", "time"])
 
     return MultiIndexDFObject(data=df_lc)

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -1,5 +1,6 @@
 import multiprocessing as mp
 import re
+from upath import UPath
 
 import astropy.units as u
 import pandas as pd
@@ -10,316 +11,91 @@ import tqdm
 
 import helpers.scale_up
 from data_structures import MultiIndexDFObject
+from hats_functions import hats_get_lightcurves
 
 
-# the catalog is stored in an AWS S3 bucket
-DATARELEASE = "dr18"
-BUCKET = "irsa-mast-tike-spitzer-data"
-CATALOG_ROOT = f"{BUCKET}/data/ZTF/lc/lc_{DATARELEASE}/"
-# We need a list of files in the dataset, but it's fairly large and we may need to send it
-# into multiple background processes. So we'll use a global variable, but lazy-load it
-# to avoid hitting the S3 bucket when this module is imported.
-CATALOG_FILES = None
+def ztf_hats_get_lightcurves(sample_table, *, radius):
+    """
+    Fetch ZTF DR23 light curves from HATs catalogs, filter and convert mags→flux.
 
-
-def ztf_get_lightcurves(sample_table, *, nworkers=6, match_radius=1/3600):
-    """Function to add the ZTF lightcurves in all three bands to a multiframe data structure.  This is the MAIN function.
+    This wrapper cross-matches your sample to the ZTF HATs object catalog,
+    pulls down the corresponding light-curve arrays, filters out bad epochs,
+    and converts AB magnitudes to fluxes in mJy.
 
     Parameters
     ----------
-    sample_table : `~astropy.table.Table`
-        Table with the coordinates and journal reference labels of the sources
-    nworkers : int or None
-        number of workers in the multiprocessing pool used in the load_lightcurves function.
-        This must be None if this function is being called from within a child process already.
-        (This function does not support nested multiprocessing.)
-    match_radius : float
-        search radius (degrees), how far from the source should the archives return results
+    sample_table : astropy.table.Table
+        Input table of targets. Must have columns:
+        
+        - ``objectid`` : int or str  
+          Unique identifier for each source.  
+        - ``coord`` : astropy.coordinates.SkyCoord  
+          SkyCoord of each source for cross-matching.  
+        - ``label`` : str  
+          Label to propagate into the output light-curve index.  
+    radius : float, optional
+        Cross-match search radius in arcseconds (default is 1.0).
 
     Returns
     -------
-    df_lc : MultiIndexDFObject
-        the main data structure to store all light curves
+    data_structures.MultiIndexDFObject
+        A container whose `.data` is a pandas DataFrame with a MultiIndex
+        (``objectid``, ``label``, ``band``, ``time``) and columns:
+        
+        - ``flux`` : float  
+          Flux in mJy, converted from AB magnitudes.  
+        - ``err`` : float  
+          1σ flux uncertainty in mJy, derived from magerr.
+
     """
-    # the catalog is in parquet format with one file per ZTF filter, field, ccd, and quadrant
-    # use a TAP query to locate which files each object is in
-    locations_df = locate_objects(sample_table, match_radius)
+    # 1) fetch the raw arrays 
+    raw = hats_get_lightcurves(
+        sample_table,
+        object_catalog_path=UPath('s3://irsa-fornax-testdata/ZTF/dr23/objects/hats'),
+        object_margin_cache=None,
+        lightcurve_catalog_path=UPath('s3://irsa-fornax-testdata/ZTF/dr23/lc/hats'),
+        lightcurve_margin_cache=None,
+        object_columns=["oid", "ra", "dec"],
+        light_curve_columns=["objectid", "hmjd", "filterid", "mag", "magerr", "catflags"],
+        id_col='objectid',
+        time_col='hmjd',
+        flux_col='mag',    # this becomes raw.data['flux']
+        err_col='magerr',  # this becomes raw.data['err']
+        radius=radius,
+        filter_id_to_name=None,
+    )
+    # 2) turn the MultiIndex into columns
+    df = raw.data.reset_index()
 
-    # the catalog is stored in an AWS S3 bucket. loop over the files and load the light curves
-    ztf_df = load_lightcurves(locations_df, nworkers=nworkers)
+    # 3) rename columns
+    df = df.rename(columns={"hmjd": "time"})
+    #these are called flux and err in the generic hats_get_lightcurves, but are really magnitudes for ztf
+    df = df.rename(columns={'flux': 'mag', 'err': 'magerr'})
 
-    # if none of the objects were found, the transform_lightcurves function will raise a ValueError
-    # so return an empty dataframe now instead of proceeding
-    if len(ztf_df.index) == 0:
-        return MultiIndexDFObject()
+    # 4) explode each array column into individual rows
+    df = df.explode(["time", "mag", "magerr"], ignore_index=True)
+    df = df.astype({
+        "time":   "float",
+        "mag":    "float",
+        "magerr": "float",
+    })
 
-    # clean and transform the data into the form needed for a MultiIndexDFObject
-    ztf_df = transform_lightcurves(ztf_df)
+    # 5) drop any epochs flagged as bad
+    # df = df.loc[df["catflags"] < 32768]
 
-    # return the light curves as a MultiIndexDFObject
-    indexes, columns = ["objectid", "label", "band", "time"], ["flux", "err"]
-    return MultiIndexDFObject(data=ztf_df.set_index(indexes)[columns].sort_index())
+    # 6) convert mag/magerr → flux/err (mJy)
+    mag    = df["mag"].to_numpy()
+    magerr = df["magerr"].to_numpy()
+    flux_up  = ((mag - magerr) * u.ABmag).to_value('mJy')
+    flux_low = ((mag + magerr) * u.ABmag).to_value('mJy')
+    df["flux"] = (mag * u.ABmag).to_value('mJy')
+    df["err"]  = (flux_up - flux_low) / 2
 
+    # 7) clean up intermediate columns (optional)
+    df = df.drop(columns=["mag", "magerr"])
 
-def file_name(filtercode, field, ccdid, qid, basedir=None):
-    """Lookup the filename for this filtercode, field, ccdid, qid.
+    # 8) re-index and return
+    df_lc = df.set_index(['objectid', 'label', 'band', 'time'])
+    
+    return MultiIndexDFObject(data=df_lc)
 
-    File name syntax starts with: {basedir}/field{field}/ztf_{field}_{filtercode}_c{ccdid}_q{qid}
-
-    Parameters
-    ----------
-    filtercode : str
-        ZTF band name
-    field : int
-        ZTF field
-    ccdid : int
-        ZTF CCD
-    qid : int
-        ZTF quadrant
-    basedir : int, optional
-        Either 0 or 1. The base directory this file is located in.
-
-    Returns
-    -------
-    file_name : str
-        Parquet file name containing this filtercode, field, ccdid, and qid.
-
-    Raises
-    ------
-    AssertionError
-        if exactly one matching file name is not found in the CATALOG_FILES list
-    """
-    # if this comes from a TAP query we won't know the basedir,
-    # so do a regex search through the CATALOG_FILES list instead
-    if basedir is None:
-        fre = re.compile(f"[01]/field{field:06}/ztf_{field:06}_{filtercode}_c{ccdid:02}_q{qid}")
-        files = [CATALOG_ROOT + f for f in filter(fre.match, CATALOG_FILES)]
-        # expecting exactly 1 filename. make it fail if there's more or less.
-        assert len(files) == 1, f"found {len(files)} files. expected 1."
-        return files[0]
-
-    f = f"{basedir}/field{field:06}/ztf_{field:06}_{filtercode}_c{ccdid:02}_q{qid}_{DATARELEASE}.parquet"
-    return CATALOG_ROOT + f
-
-
-def locate_objects(sample_table, match_radius, chunksize=10000):
-    """The catalog's parquet files are organized by filter, field, CCD, and quadrant. Use TAP to look them up.
-
-    https://irsa.ipac.caltech.edu/docs/program_interface/TAP.html
-
-    Parameters
-    ----------
-    sample_table : `~astropy.table.Table`
-        Table with the coordinates and journal reference labels of the sources
-    match_radius : float
-        search radius (degrees), how far from the source should the archives return results
-    chunksize : int
-        This tap query is much faster when submitting less than ~10,000 coords at a time
-        so iterate over chunks of coords_tbl and then concat results.
-
-    Returns
-    -------
-    locations_df : pd.DataFrame
-        Dataframe with ZTF field, CCD, quadrant and other information that identifies each `sample_table`
-        object and which parquet files it is in. One row per ZTF objectid.
-    """
-    # setup for tap query
-    tap_service = pyvo.dal.TAPService("https://irsa.ipac.caltech.edu/TAP")
-    # construct table to be uploaded
-    upload_table = sample_table["objectid", "label"]
-    upload_table.convert_unicode_to_bytestring()  # TAP requires strings to be encoded
-    upload_table["ra"] = sample_table["coord"].ra.deg
-    upload_table["dec"] = sample_table["coord"].dec.deg
-    # construct the query
-    sample_cols = [f"sample.{c}" for c in ["objectid", "label"]]
-    ztf_cols = [f"ztf.{c}" for c in ["oid", "filtercode", "field", "ccdid", "qid", "ra", "dec"]]
-    select_cols = ', '.join(sample_cols + ztf_cols)
-    query = f"""SELECT {select_cols}
-        FROM ztf_objects_{DATARELEASE} ztf, TAP_UPLOAD.sample sample
-        WHERE CONTAINS(
-            POINT('ICRS', sample.ra, sample.dec), CIRCLE('ICRS', ztf.ra, ztf.dec, {match_radius})
-        )=1"""
-
-    # do the tap calls
-    locations = []
-    for i in tqdm.trange(0, len(upload_table), chunksize):
-        result = tap_service.run_async(query, uploads={"sample": upload_table[i: i + chunksize]})
-        locations.append(result.to_table().to_pandas())
-
-    # locations may contain more than one ZTF object id per band (e.g., yang sample sample_table[11])
-    # Sánchez-Sáez et al., 2021 (2021AJ....162..206S)
-    # return all the data -- transform_lightcurves will choose which to keep
-    return pd.concat(locations, ignore_index=True)
-
-
-def load_lightcurves(locations_df, nworkers=6, chunksize=100):
-    """Loop over the catalog's parquet files (stored in an AWS S3 bucket) and load light curves.
-
-    Parameters
-    ----------
-    locations_df : pd.DataFrame
-        Dataframe with ZTF field, CCD, quadrant and other information that identifies each `coord` object
-        and which parquet files it is in.
-    nworkers : int or None
-        Number of workers in the multiprocessing pool. Use None to turn off multiprocessing. This must be None
-        if this function is being called from within a child process (no nested multiprocessing).
-    chunksize : int
-        Number of files sent to the workers.
-
-    Returns
-    -------
-    ztf_df : pd.DataFrame
-        Dataframe of light curves. Expect one row per oid in locations_df. Each row
-        stores a full light curve. Elements in the columns "mag", "hmjd", etc. are arrays.
-    """
-    # We need to return an empty dataframe if no matches are found. If the TAP query returned matches
-    # but none of them are found in the parquet files, this function will naturally return an empty dataframe.
-    # But if the TAP query found no matches, pd.concat (below) will throw a ValueError. Return now to avoid this.
-    if len(locations_df.index) == 0:
-        return pd.DataFrame()
-
-    # If CATALOG_FILES hasn't been loaded yet, do it now. We'll use the checksums file to get the list.
-    global CATALOG_FILES
-    if CATALOG_FILES is None:
-        CATALOG_FILES = (
-            pd.read_table(f"s3://{CATALOG_ROOT}checksum.md5", sep="\s+",
-                          names=["md5", "path"], usecols=["path"])
-            .squeeze()  # there's only 1 column. squeeze it into a Series
-            .str.removeprefix("./")
-            .to_list()
-        )
-
-    # one group per parquet file
-    location_grps = locations_df.groupby(["filtercode", "field", "ccdid", "qid"])
-
-    # if no multiprocessing requested, loop over files serially and load data. return immediately
-    if nworkers is None:
-        lightcurves = []
-        for location in tqdm.auto.tqdm(location_grps):
-            lightcurves.append(load_lightcurves_one_file(location))
-        return pd.concat(lightcurves, ignore_index=True)
-
-    # if we get here, multiprocessing has been requested
-
-    # make sure the chunksize isn't so big that some workers will sit idle
-    if len(location_grps) < nworkers * chunksize:
-        chunksize = len(location_grps) // nworkers + 1
-
-    # start a pool of background processes to load data in parallel
-    with mp.Pool(nworkers, initializer=helpers.scale_up._init_worker) as pool:
-        lightcurves = []
-        # use imap because it's lazier than map and can reduce memory usage for long iterables
-        # use unordered because we don't care about the order in which results are returned
-        # using a large chunksize can make it much faster than the default of 1
-        for ztf_df in tqdm.auto.tqdm(
-            pool.imap_unordered(load_lightcurves_one_file, location_grps, chunksize=chunksize),
-            total=len(location_grps)  # must tell tqdm how many files we're iterating over
-        ):
-            lightcurves.append(ztf_df)
-
-    return pd.concat(lightcurves, ignore_index=True)
-
-
-def load_lightcurves_one_file(location):
-    """Load light curves from one file.
-
-    Parameters
-    ----------
-    location : tuple
-        tuple containing two elements that describe one parquet file. the elements are:
-            location_keys : tuple(str, int, int int)
-                Keys that uniquely identify a ZTF location (filtercode, field, CCD, and quadrant).
-                Used to lookup the file name.
-            location_df : pd.DataFrame
-                Dataframe of objects in this location. Used to filter data from this file.
-
-    Returns
-    -------
-    ztf_df : pd.DataFrame
-        Dataframe of light curves. Expect one row per oid in location_df. Each row
-        stores a full light curve. Elements in the columns "mag", "hmjd", etc. are arrays.
-    """
-    location_keys, location_df = location
-
-    # load light curves from this file, filtering for the ZTF object IDs in location_df.
-    # we could use pandas or pyarrow. pyarrow plays nicer with multiprocessing. pandas requires
-    # "spawning" new processes, which causes leaked semaphores in some cases.
-    ztf_df = pyarrow.parquet.read_table(
-        file_name(*location_keys),
-        filesystem=pyarrow.fs.S3FileSystem(region="us-east-1"),
-        columns=["objectid", "hmjd", "mag", "magerr", "catflags"],
-        filters=[("objectid", "in", location_df["oid"].to_list())],
-    ).to_pandas()
-
-    # in the parquet files, "objectid" is the ZTF object ID
-    # in the MultiIndexDFObject, "objectid" is the ID of a sample_table object
-    # rename the ZTF object ID that just got loaded to avoid confusion
-    ztf_df = ztf_df.rename(columns={"objectid": "oid"})
-
-    # add the sample_table object ID and label columns by mapping thru the ZTF object ID
-    oidmap = location_df.set_index("oid")["objectid"].to_dict()
-    lblmap = location_df.set_index("oid")["label"].to_dict()
-    ztf_df["objectid"] = ztf_df["oid"].map(oidmap)
-    ztf_df["label"] = ztf_df["oid"].map(lblmap)
-
-    # add the band (i.e., filtercode)
-    ztf_df["band"] = location_keys[0]
-
-    return ztf_df
-
-
-def transform_lightcurves(ztf_df):
-    """Clean and transform the data into the form expected for a `MultiIndexDFObject`.
-
-    Parameters
-    ----------
-    ztf_df : pd.DataFrame
-        Dataframe of light curves as returned by `load_lightcurves`.
-
-    Returns
-    -------
-    ztf_df : pd.DataFrame
-        The input dataframe, cleaned and transformed.
-    """
-    # ztf_df might have more than one light curve per (band + objectid) if the ra/dec is close
-    # to a CCD-quadrant boundary (Sanchez-Saez et al., 2021). keep the one with the most datapoints
-    indexes_to_keep = []
-    for _, singleband_object in ztf_df.groupby(["objectid", "band"]):
-        if len(singleband_object.index) == 1:
-            indexes_to_keep.extend(singleband_object.index)
-        else:
-            npoints = singleband_object["mag"].str.len()
-            npointsmax_object = singleband_object.loc[npoints == npoints.max()]
-            # this may still have more than one light curve if they happen to have the same number
-            # of datapoints (e.g., Yang sample sample_table[7], band 'zr').
-            # arbitrarily pick the one with the min oid.
-            # depending on your science, you may want (e.g.,) the largest timespan instead
-            if len(npointsmax_object.index) == 1:
-                indexes_to_keep.extend(npointsmax_object.index)
-            else:
-                minoid = npointsmax_object.oid.min()
-                indexes_to_keep.extend(npointsmax_object.loc[npointsmax_object.oid == minoid].index)
-    ztf_df = ztf_df.loc[sorted(indexes_to_keep)]
-
-    # store "hmjd" as "time".
-    # note that other light curves in this notebook will have "time" as MJD instead of HMJD.
-    # if your science depends on precise times, this will need to be corrected.
-    ztf_df = ztf_df.rename(columns={"hmjd": "time"})
-
-    # "explode" the data structure into one row per light curve point and set the correct dtypes
-    # note that this operation may require 6+ times the RAM used for ztf_df up to now
-    ztf_df = ztf_df.explode(["time", "mag", "magerr", "catflags"], ignore_index=True)
-    ztf_df = ztf_df.astype({"time": "float", "mag": "float", "magerr": "float", "catflags": "int"})
-
-    # remove data flagged as bad
-    ztf_df = ztf_df.loc[ztf_df["catflags"] < 32768, :]
-
-    # calc flux [https://arxiv.org/pdf/1902.01872.pdf zeropoint corrections already applied]
-    mag = ztf_df["mag"].to_numpy()
-    magerr = ztf_df["magerr"].to_numpy()
-    fluxupper = ((mag - magerr) * u.ABmag).to_value('mJy')
-    fluxlower = ((mag + magerr) * u.ABmag).to_value('mJy')
-    ztf_df["flux"] = (mag * u.ABmag).to_value('mJy')
-    ztf_df["err"] = (fluxupper - fluxlower) / 2
-
-    return ztf_df


### PR DESCRIPTION
This PR does 3 main things
1) makes a hats_get_lightcurves function which generalizes grabbing light curves from hats files.  This is with the hope that more files in the future will also be in this format.  For now, ZTF and Panstarrs are in similar enough formats to use this general function.

2) re-writes the panstarrs_get_lightcurves functions to be a wrapper around hats_get_lightcurves.  We were already using a hats catalog for panstarrs, but the change here is using the generic function written for 1) above.

3) re-writes ztf_get_lightcurves function to be a wrapper around hats_get_lightcurves.  This is a complete re-write of that function and is nothing like the original function.  Unfortunately I can not benchmark it against the old function because that is not working with the old data release due to issue #371.

This PR will close #371 