### PR TITLE
Fix another mathtext occurance

### DIFF
--- a/forced_photometry/code_src/plot_SED.py
+++ b/forced_photometry/code_src/plot_SED.py
@@ -20,7 +20,7 @@ def plot_SED(obj, df):
     ax.errorbar(wavelength, flux, yerr = fluxerr)
 
     #set up labels
-    ax.set(xlabel = 'Wavelength (microns)', ylabel = "Flux ($\mu$Jy)", title = 'SED')
+    ax.set(xlabel = 'Wavelength (microns)', ylabel = r"Flux ($\mu$Jy)", title = 'SED')
     plt.show()
     
     return


### PR DESCRIPTION
Fix another mathtext warning in forced photometry notebook similar to #415. The issue is reported in #414 