### PR TITLE
Add ztf hats

### DIFF
--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -67,8 +67,8 @@ def panstarrs_get_lightcurves(sample_table, *, radius=1):
 
     # plan to cross match panstarrs object with my sample
     # only keep the best match
-    matched_objects = panstarrs_object.crossmatch(
-        sample_lsdb,
+    matched_objects = sample_lsdb.crossmatch(
+        panstarrs_object,
         radius_arcsec=radius,
         n_neighbors=1,
         suffixes=("", "")

--- a/light_curves/code_src/panstarrs_functions.py
+++ b/light_curves/code_src/panstarrs_functions.py
@@ -6,7 +6,7 @@ from dask.distributed import Client
 from data_structures import MultiIndexDFObject
 from upath import UPath
 
-# panstarrs light curves from hipscat catalog in S3 using lsdb
+# panstarrs light curves from hats catalog in S3 using lsdb
 
 
 def panstarrs_get_lightcurves(sample_table, *, radius=1):

--- a/light_curves/code_src/wise_functions.py
+++ b/light_curves/code_src/wise_functions.py
@@ -100,7 +100,7 @@ def load_lightcurves(locations, radius, bandlist):
     """
     # load the catalog's metadata as a pyarrow dataset. this will be used to query the catalog.
     # the catalog is stored in an AWS S3 bucket
-    fs = pyarrow.fs.S3FileSystem(region="us-west-2")
+    fs = pyarrow.fs.S3FileSystem(region="us-west-2",anonymous=True )
     bucket = "nasa-irsa-wise"
     catalog_root = f"{bucket}/unwise/neo7/catalogs/time_domain/healpix_k{K}/unwise-neo7-time_domain-healpix_k{K}.parquet"
     dataset = pyarrow.dataset.parquet_dataset(

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -34,7 +34,7 @@ def ztf_get_lightcurves(sample_table, *, radius=1.0):
         ]
     )
 
-    # 2) Convert Astropy table → pandas → LSDB catalog, then persist sample only
+    # 2) Convert Astropy table → pandas → LSDB catalog
     sample_df = pd.DataFrame({
         'objectid': sample_table['objectid'],
         'ra_deg':   sample_table['coord'].ra.deg,

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -1,109 +1,109 @@
-import numpy as np
-from astropy.table import Table
-import lsdb
 from dask.distributed import Client
-from data_structures import MultiIndexDFObject
-from upath import UPath
-import astropy.units as u
 import pandas as pd
+import lsdb
+from astropy import units as u
+from upath import UPath
 from data_structures import MultiIndexDFObject
 
-def ztf_get_lightcurves(sample_table, *, radius=1):
-    """Searches ZTF hats files for light curves from a list of input coordinates.
-
+def ztf_get_lightcurves(sample_table, *, radius=1.0):
+    """
+    Search ZTF HATS files for light curves around a list of target coordinates
+    
     Parameters
     ----------
-    sample_table : `~astropy.table.Table`
-        Table with the coordinates and journal reference labels of the sources
-    radius : float
-        search radius, how far from the source should the archives return results
+    sample_table : astropy.table.Table
+        Table with columns:
+        - objectid : identifier for each target
+        - coord : SkyCoord object for each target position
+        - label : user-defined label for each target
+    radius : float, optional
+        Search radius in arcseconds. Default is 1.0.
 
     Returns
     -------
-    df_lc : MultiIndexDFObject
-        the main data structure to store all light curves
-
-    note that other light curves in this notebook will have "time" as MJD instead of HMJD.
-    if your science depends on precise times, this will need to be corrected.
-
-    """
-
-    # read in the ZTF light curves to lsdb
+    MultiIndexDFObject
+     """
+    # 1) Start Dask client & read full ZTF light-curve catalog
+    client = Client()
+    suffix = 'ztf_lc_dr23'
     ztf_lc = lsdb.read_hats(
-        UPath('s3://irsa-fornax-testdata/ZTF/dr23/lc/hats'),
-        #margin_cache=UPath('s3://stpubdata/panstarrs/ps1/public/hats/detection_10arcs', anon=True),
-        columns=["objectid","objra", "objdec", "hmjd", "filterid", "mag", "magerr", "catflags"]
+        UPath('s3://irsa-fornax-testdata/ZTF/dr23/lc/'),
+        columns=[
+            "objectid", "objra", "objdec",
+            "hmjd", "filterid", "mag", "magerr", "catflags"
+        ]
     )
-    # convert astropy table to pandas dataframe
-    # special care for the SkyCoords in the table
-    sample_df = pd.DataFrame({'objectid': sample_table['objectid'],
-                              'ra_deg': sample_table['coord'].ra.deg,
-                              'dec_deg': sample_table['coord'].dec.deg,
-                              'label': sample_table['label']})
-    
-    #start a dask client for lsdb to use
-    client = Client()  
-    
-    # convert dataframe to hipscat
+
+    # 2) Convert Astropy table → pandas → LSDB catalog, then persist sample only
+    sample_df = pd.DataFrame({
+        'objectid': sample_table['objectid'],
+        'ra_deg':   sample_table['coord'].ra.deg,
+        'dec_deg':  sample_table['coord'].dec.deg,
+        'label':    sample_table['label'],
+    })
     sample_lsdb = lsdb.from_dataframe(
         sample_df,
         ra_column="ra_deg",
         dec_column="dec_deg",
         margin_threshold=10,
-        # Optimize partition size
         drop_empty_siblings=True
     )
-
-    # plan to cross match ZTF object with my sample
-    # only keep the best match
-    matched_lc = ztf_lc.crossmatch(
-        sample_lsdb,
-        radius_arcsec=radius,
-        n_neighbors=1,
-    )
-
-    # here is where the actual work gets done
-    # compute the cross match with object table
-    df = matched_lc.compute()
-
-    #done with dask
-    client.close() 
     
-    # explode each array column into individual rows
-    df = df.explode(["hmjd_ztf_lc_dr23", 
-                     "mag_ztf_lc_dr23", 
-                     "magerr_ztf_lc_dr23",
-                    "catflags_ztf_lc_dr23"], ignore_index=True)
-    df = df.astype({
-        "hmjd_ztf_lc_dr23":   "float",
-        "mag_ztf_lc_dr23":    "float",
-        "magerr_ztf_lc_dr23": "float",
-        "catflags_ztf_lc_dr23": "int"
-    })
+    # 2b) grab the HEALPix tiles that actually cover your sample
+    sample_tiles = sample_lsdb.get_healpix_pixels()
+
     
-    # drop any epochs flagged as bad
-    df = df.loc[df["catflags_ztf_lc_dr23"] < 32768]
+    # 3) Cross-match per band, pre-filtering by tile_ids
+    band_map = {1: "ztf_g", 2: "ztf_r", 3: "ztf_i"}
+    per_band_dfs = []
 
-    # map ZTF filter IDs → simple band names
-    filter_map = {1: 'ztf_g', 2: 'ztf_r', 3: 'ztf_i'}
-    df['band'] = df['filterid_ztf_lc_dr23'].map(filter_map).astype(str)
+    for fid, band_name in band_map.items():
+        # 3a) filter to one band and select relevant sky tiles
+        ztf_band = ztf_lc.query(f"filterid == {fid}")
 
-    # convert mag/magerr → flux/err (mJy)
-    mag    = df["mag_ztf_lc_dr23"].to_numpy()
-    magerr = df["magerr_ztf_lc_dr23"].to_numpy()
+        # 3b) crossmatch: sample (left) → filtered band (right)
+        matched = sample_lsdb.crossmatch(
+            ztf_band,
+            radius_arcsec=radius,
+            n_neighbors=1
+        )
+        df = matched.compute()
+
+        # 3c) explode any length-1 arrays
+        array_cols = [c for c in df.columns if isinstance(df.iloc[0][c], (list, tuple))]
+        if array_cols:
+            df = df.explode(array_cols, ignore_index=True)
+
+        # 3d) cast, drop bad flags, assign band
+        df = df.astype({
+            f"hmjd_{suffix}":   float,
+            f"mag_{suffix}":    float,
+            f"magerr_{suffix}": float,
+            f"catflags_{suffix}": int
+        })
+        df = df[df[f"catflags_{suffix}"] < 32768]
+        df["band"] = band_name
+
+        per_band_dfs.append(df)
+
+    client.close()
+
+    # 4) Concatenate, convert mags → fluxes, and build final MultiIndex
+    df_all = pd.concat(per_band_dfs, ignore_index=True)
+    mag    = df_all[f"mag_{suffix}"].to_numpy()
+    magerr = df_all[f"magerr_{suffix}"].to_numpy()
     flux_up  = ((mag - magerr) * u.ABmag).to_value('mJy')
     flux_low = ((mag + magerr) * u.ABmag).to_value('mJy')
-    df["flux"] = (mag * u.ABmag).to_value('mJy')
-    df["err"]  = (flux_up - flux_low) / 2
+    df_all["flux"] = (mag * u.ABmag).to_value('mJy')
+    df_all["err"]  = (flux_up - flux_low) / 2
 
-    # make the dataframe of light curves
     df_lc = pd.DataFrame({
-        'flux': df["flux"],
-        'err': df["err"],
-        'time': df["hmjd_ztf_lc_dr23"],
-        'objectid': df['objectid_from_lsdb_dataframe'],
-        'band': df['band'],
-        'label': df['label_from_lsdb_dataframe']
+        'flux':     df_all["flux"],
+        'err':      df_all["err"],
+        'time':     df_all[f"hmjd_{suffix}"],
+        'objectid': df_all['objectid_from_lsdb_dataframe'],
+        'label':    df_all['label_from_lsdb_dataframe'],
+        'band':     df_all['band']
     }).set_index(["objectid", "label", "band", "time"])
 
     return MultiIndexDFObject(data=df_lc)

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -24,7 +24,7 @@ def ztf_get_lightcurves(sample_table, *, radius=1.0):
     MultiIndexDFObject
      """
     # 1) Start Dask client & read full ZTF light-curve catalog
-    client = Client()
+    client = Client(threads_per_worker=2, memory_limit=None)
     suffix = 'ztf_lc_dr23'
     ztf_lc = lsdb.read_hats(
         UPath('s3://irsa-fornax-testdata/ZTF/dr23/lc/'),
@@ -49,11 +49,7 @@ def ztf_get_lightcurves(sample_table, *, radius=1.0):
         drop_empty_siblings=True
     )
     
-    # 2b) grab the HEALPix tiles that actually cover your sample
-    sample_tiles = sample_lsdb.get_healpix_pixels()
-
-    
-    # 3) Cross-match per band, pre-filtering by tile_ids
+    # 3) Cross-match per band
     band_map = {1: "ztf_g", 2: "ztf_r", 3: "ztf_i"}
     per_band_dfs = []
 

--- a/light_curves/code_src/ztf_functions.py
+++ b/light_curves/code_src/ztf_functions.py
@@ -1,26 +1,12 @@
-import multiprocessing as mp
-import re
-
-import astropy.units as u
-import pandas as pd
-import pyarrow.fs
-import pyarrow.parquet
-import pyvo
-import tqdm
-
-import helpers.scale_up
-from data_structures import MultiIndexDFObject
-
 import numpy as np
-import pandas as pd
 from astropy.table import Table
 import lsdb
 from dask.distributed import Client
 from data_structures import MultiIndexDFObject
 from upath import UPath
-
-# panstarrs light curves from hipscat catalog in S3 using lsdb
-
+import astropy.units as u
+import pandas as pd
+from data_structures import MultiIndexDFObject
 
 def ztf_get_lightcurves(sample_table, *, radius=1):
     """Searches ZTF hats files for light curves from a list of input coordinates.
@@ -54,8 +40,9 @@ def ztf_get_lightcurves(sample_table, *, radius=1):
                               'ra_deg': sample_table['coord'].ra.deg,
                               'dec_deg': sample_table['coord'].dec.deg,
                               'label': sample_table['label']})
-
-    client = Client()  #start a dask client for lsdb to use
+    
+    #start a dask client for lsdb to use
+    client = Client()  
     
     # convert dataframe to hipscat
     sample_lsdb = lsdb.from_dataframe(
@@ -79,8 +66,9 @@ def ztf_get_lightcurves(sample_table, *, radius=1):
     # compute the cross match with object table
     df = matched_lc.compute()
 
-    client.close() #done with dask
-    print("df columnsafter compute:", df.columns)
+    #done with dask
+    client.close() 
+    
     # explode each array column into individual rows
     df = df.explode(["hmjd_ztf_lc_dr23", 
                      "mag_ztf_lc_dr23", 
@@ -96,6 +84,10 @@ def ztf_get_lightcurves(sample_table, *, radius=1):
     # drop any epochs flagged as bad
     df = df.loc[df["catflags_ztf_lc_dr23"] < 32768]
 
+    # map ZTF filter IDs → simple band names
+    filter_map = {1: 'ztf_g', 2: 'ztf_r', 3: 'ztf_i'}
+    df['band'] = df['filterid_ztf_lc_dr23'].map(filter_map).astype(str)
+
     # convert mag/magerr → flux/err (mJy)
     mag    = df["mag_ztf_lc_dr23"].to_numpy()
     magerr = df["magerr_ztf_lc_dr23"].to_numpy()
@@ -105,329 +97,14 @@ def ztf_get_lightcurves(sample_table, *, radius=1):
     df["err"]  = (flux_up - flux_low) / 2
 
     # make the dataframe of light curves
-
     df_lc = pd.DataFrame({
         'flux': df["flux"],
         'err': df["err"],
         'time': df["hmjd_ztf_lc_dr23"],
         'objectid': df['objectid_from_lsdb_dataframe'],
-        'band': df['filterid_ztf_lc_dr23'],
+        'band': df['band'],
         'label': df['label_from_lsdb_dataframe']
     }).set_index(["objectid", "label", "band", "time"])
 
     return MultiIndexDFObject(data=df_lc)
 
-
-
-
-# the catalog is stored in an AWS S3 bucket
-DATARELEASE = "dr18"
-BUCKET = "irsa-mast-tike-spitzer-data"
-CATALOG_ROOT = f"{BUCKET}/data/ZTF/lc/lc_{DATARELEASE}/"
-# We need a list of files in the dataset, but it's fairly large and we may need to send it
-# into multiple background processes. So we'll use a global variable, but lazy-load it
-# to avoid hitting the S3 bucket when this module is imported.
-CATALOG_FILES = None
-
-
-def ztf_get_lightcurves_old(sample_table, *, nworkers=6, match_radius=1/3600):
-    """Function to add the ZTF lightcurves in all three bands to a multiframe data structure.  This is the MAIN function.
-
-    Parameters
-    ----------
-    sample_table : `~astropy.table.Table`
-        Table with the coordinates and journal reference labels of the sources
-    nworkers : int or None
-        number of workers in the multiprocessing pool used in the load_lightcurves function.
-        This must be None if this function is being called from within a child process already.
-        (This function does not support nested multiprocessing.)
-    match_radius : float
-        search radius (degrees), how far from the source should the archives return results
-
-    Returns
-    -------
-    df_lc : MultiIndexDFObject
-        the main data structure to store all light curves
-    """
-    # the catalog is in parquet format with one file per ZTF filter, field, ccd, and quadrant
-    # use a TAP query to locate which files each object is in
-    locations_df = locate_objects(sample_table, match_radius)
-
-    # the catalog is stored in an AWS S3 bucket. loop over the files and load the light curves
-    ztf_df = load_lightcurves(locations_df, nworkers=nworkers)
-
-    # if none of the objects were found, the transform_lightcurves function will raise a ValueError
-    # so return an empty dataframe now instead of proceeding
-    if len(ztf_df.index) == 0:
-        return MultiIndexDFObject()
-
-    # clean and transform the data into the form needed for a MultiIndexDFObject
-    ztf_df = transform_lightcurves(ztf_df)
-
-    # return the light curves as a MultiIndexDFObject
-    indexes, columns = ["objectid", "label", "band", "time"], ["flux", "err"]
-    return MultiIndexDFObject(data=ztf_df.set_index(indexes)[columns].sort_index())
-
-
-def file_name(filtercode, field, ccdid, qid, basedir=None):
-    """Lookup the filename for this filtercode, field, ccdid, qid.
-
-    File name syntax starts with: {basedir}/field{field}/ztf_{field}_{filtercode}_c{ccdid}_q{qid}
-
-    Parameters
-    ----------
-    filtercode : str
-        ZTF band name
-    field : int
-        ZTF field
-    ccdid : int
-        ZTF CCD
-    qid : int
-        ZTF quadrant
-    basedir : int, optional
-        Either 0 or 1. The base directory this file is located in.
-
-    Returns
-    -------
-    file_name : str
-        Parquet file name containing this filtercode, field, ccdid, and qid.
-
-    Raises
-    ------
-    AssertionError
-        if exactly one matching file name is not found in the CATALOG_FILES list
-    """
-    # if this comes from a TAP query we won't know the basedir,
-    # so do a regex search through the CATALOG_FILES list instead
-    if basedir is None:
-        fre = re.compile(f"[01]/field{field:06}/ztf_{field:06}_{filtercode}_c{ccdid:02}_q{qid}")
-        files = [CATALOG_ROOT + f for f in filter(fre.match, CATALOG_FILES)]
-        # expecting exactly 1 filename. make it fail if there's more or less.
-        assert len(files) == 1, f"found {len(files)} files. expected 1."
-        return files[0]
-
-    f = f"{basedir}/field{field:06}/ztf_{field:06}_{filtercode}_c{ccdid:02}_q{qid}_{DATARELEASE}.parquet"
-    return CATALOG_ROOT + f
-
-
-def locate_objects(sample_table, match_radius, chunksize=10000):
-    """The catalog's parquet files are organized by filter, field, CCD, and quadrant. Use TAP to look them up.
-
-    https://irsa.ipac.caltech.edu/docs/program_interface/TAP.html
-
-    Parameters
-    ----------
-    sample_table : `~astropy.table.Table`
-        Table with the coordinates and journal reference labels of the sources
-    match_radius : float
-        search radius (degrees), how far from the source should the archives return results
-    chunksize : int
-        This tap query is much faster when submitting less than ~10,000 coords at a time
-        so iterate over chunks of coords_tbl and then concat results.
-
-    Returns
-    -------
-    locations_df : pd.DataFrame
-        Dataframe with ZTF field, CCD, quadrant and other information that identifies each `sample_table`
-        object and which parquet files it is in. One row per ZTF objectid.
-    """
-    # setup for tap query
-    tap_service = pyvo.dal.TAPService("https://irsa.ipac.caltech.edu/TAP")
-    # construct table to be uploaded
-    upload_table = sample_table["objectid", "label"]
-    upload_table.convert_unicode_to_bytestring()  # TAP requires strings to be encoded
-    upload_table["ra"] = sample_table["coord"].ra.deg
-    upload_table["dec"] = sample_table["coord"].dec.deg
-    # construct the query
-    sample_cols = [f"sample.{c}" for c in ["objectid", "label"]]
-    ztf_cols = [f"ztf.{c}" for c in ["oid", "filtercode", "field", "ccdid", "qid", "ra", "dec"]]
-    select_cols = ', '.join(sample_cols + ztf_cols)
-    query = f"""SELECT {select_cols}
-        FROM ztf_objects_{DATARELEASE} ztf, TAP_UPLOAD.sample sample
-        WHERE CONTAINS(
-            POINT('ICRS', sample.ra, sample.dec), CIRCLE('ICRS', ztf.ra, ztf.dec, {match_radius})
-        )=1"""
-
-    # do the tap calls
-    locations = []
-    for i in tqdm.trange(0, len(upload_table), chunksize):
-        result = tap_service.run_async(query, uploads={"sample": upload_table[i: i + chunksize]})
-        locations.append(result.to_table().to_pandas())
-
-    # locations may contain more than one ZTF object id per band (e.g., yang sample sample_table[11])
-    # Sánchez-Sáez et al., 2021 (2021AJ....162..206S)
-    # return all the data -- transform_lightcurves will choose which to keep
-    return pd.concat(locations, ignore_index=True)
-
-
-def load_lightcurves(locations_df, nworkers=6, chunksize=100):
-    """Loop over the catalog's parquet files (stored in an AWS S3 bucket) and load light curves.
-
-    Parameters
-    ----------
-    locations_df : pd.DataFrame
-        Dataframe with ZTF field, CCD, quadrant and other information that identifies each `coord` object
-        and which parquet files it is in.
-    nworkers : int or None
-        Number of workers in the multiprocessing pool. Use None to turn off multiprocessing. This must be None
-        if this function is being called from within a child process (no nested multiprocessing).
-    chunksize : int
-        Number of files sent to the workers.
-
-    Returns
-    -------
-    ztf_df : pd.DataFrame
-        Dataframe of light curves. Expect one row per oid in locations_df. Each row
-        stores a full light curve. Elements in the columns "mag", "hmjd", etc. are arrays.
-    """
-    # We need to return an empty dataframe if no matches are found. If the TAP query returned matches
-    # but none of them are found in the parquet files, this function will naturally return an empty dataframe.
-    # But if the TAP query found no matches, pd.concat (below) will throw a ValueError. Return now to avoid this.
-    if len(locations_df.index) == 0:
-        return pd.DataFrame()
-
-    # If CATALOG_FILES hasn't been loaded yet, do it now. We'll use the checksums file to get the list.
-    global CATALOG_FILES
-    if CATALOG_FILES is None:
-        CATALOG_FILES = (
-            pd.read_table(f"s3://{CATALOG_ROOT}checksum.md5", sep="\s+",
-                          names=["md5", "path"], usecols=["path"])
-            .squeeze()  # there's only 1 column. squeeze it into a Series
-            .str.removeprefix("./")
-            .to_list()
-        )
-
-    # one group per parquet file
-    location_grps = locations_df.groupby(["filtercode", "field", "ccdid", "qid"])
-
-    # if no multiprocessing requested, loop over files serially and load data. return immediately
-    if nworkers is None:
-        lightcurves = []
-        for location in tqdm.auto.tqdm(location_grps):
-            lightcurves.append(load_lightcurves_one_file(location))
-        return pd.concat(lightcurves, ignore_index=True)
-
-    # if we get here, multiprocessing has been requested
-
-    # make sure the chunksize isn't so big that some workers will sit idle
-    if len(location_grps) < nworkers * chunksize:
-        chunksize = len(location_grps) // nworkers + 1
-
-    # start a pool of background processes to load data in parallel
-    with mp.Pool(nworkers, initializer=helpers.scale_up._init_worker) as pool:
-        lightcurves = []
-        # use imap because it's lazier than map and can reduce memory usage for long iterables
-        # use unordered because we don't care about the order in which results are returned
-        # using a large chunksize can make it much faster than the default of 1
-        for ztf_df in tqdm.auto.tqdm(
-            pool.imap_unordered(load_lightcurves_one_file, location_grps, chunksize=chunksize),
-            total=len(location_grps)  # must tell tqdm how many files we're iterating over
-        ):
-            lightcurves.append(ztf_df)
-
-    return pd.concat(lightcurves, ignore_index=True)
-
-
-def load_lightcurves_one_file(location):
-    """Load light curves from one file.
-
-    Parameters
-    ----------
-    location : tuple
-        tuple containing two elements that describe one parquet file. the elements are:
-            location_keys : tuple(str, int, int int)
-                Keys that uniquely identify a ZTF location (filtercode, field, CCD, and quadrant).
-                Used to lookup the file name.
-            location_df : pd.DataFrame
-                Dataframe of objects in this location. Used to filter data from this file.
-
-    Returns
-    -------
-    ztf_df : pd.DataFrame
-        Dataframe of light curves. Expect one row per oid in location_df. Each row
-        stores a full light curve. Elements in the columns "mag", "hmjd", etc. are arrays.
-    """
-    location_keys, location_df = location
-
-    # load light curves from this file, filtering for the ZTF object IDs in location_df.
-    # we could use pandas or pyarrow. pyarrow plays nicer with multiprocessing. pandas requires
-    # "spawning" new processes, which causes leaked semaphores in some cases.
-    ztf_df = pyarrow.parquet.read_table(
-        file_name(*location_keys),
-        filesystem=pyarrow.fs.S3FileSystem(region="us-east-1"),
-        columns=["objectid", "hmjd", "mag", "magerr", "catflags"],
-        filters=[("objectid", "in", location_df["oid"].to_list())],
-    ).to_pandas()
-
-    # in the parquet files, "objectid" is the ZTF object ID
-    # in the MultiIndexDFObject, "objectid" is the ID of a sample_table object
-    # rename the ZTF object ID that just got loaded to avoid confusion
-    ztf_df = ztf_df.rename(columns={"objectid": "oid"})
-
-    # add the sample_table object ID and label columns by mapping thru the ZTF object ID
-    oidmap = location_df.set_index("oid")["objectid"].to_dict()
-    lblmap = location_df.set_index("oid")["label"].to_dict()
-    ztf_df["objectid"] = ztf_df["oid"].map(oidmap)
-    ztf_df["label"] = ztf_df["oid"].map(lblmap)
-
-    # add the band (i.e., filtercode)
-    ztf_df["band"] = location_keys[0]
-
-    return ztf_df
-
-
-def transform_lightcurves(ztf_df):
-    """Clean and transform the data into the form expected for a `MultiIndexDFObject`.
-
-    Parameters
-    ----------
-    ztf_df : pd.DataFrame
-        Dataframe of light curves as returned by `load_lightcurves`.
-
-    Returns
-    -------
-    ztf_df : pd.DataFrame
-        The input dataframe, cleaned and transformed.
-    """
-    # ztf_df might have more than one light curve per (band + objectid) if the ra/dec is close
-    # to a CCD-quadrant boundary (Sanchez-Saez et al., 2021). keep the one with the most datapoints
-    indexes_to_keep = []
-    for _, singleband_object in ztf_df.groupby(["objectid", "band"]):
-        if len(singleband_object.index) == 1:
-            indexes_to_keep.extend(singleband_object.index)
-        else:
-            npoints = singleband_object["mag"].str.len()
-            npointsmax_object = singleband_object.loc[npoints == npoints.max()]
-            # this may still have more than one light curve if they happen to have the same number
-            # of datapoints (e.g., Yang sample sample_table[7], band 'zr').
-            # arbitrarily pick the one with the min oid.
-            # depending on your science, you may want (e.g.,) the largest timespan instead
-            if len(npointsmax_object.index) == 1:
-                indexes_to_keep.extend(npointsmax_object.index)
-            else:
-                minoid = npointsmax_object.oid.min()
-                indexes_to_keep.extend(npointsmax_object.loc[npointsmax_object.oid == minoid].index)
-    ztf_df = ztf_df.loc[sorted(indexes_to_keep)]
-
-    # store "hmjd" as "time".
-    # note that other light curves in this notebook will have "time" as MJD instead of HMJD.
-    # if your science depends on precise times, this will need to be corrected.
-    ztf_df = ztf_df.rename(columns={"hmjd": "time"})
-
-    # "explode" the data structure into one row per light curve point and set the correct dtypes
-    # note that this operation may require 6+ times the RAM used for ztf_df up to now
-    ztf_df = ztf_df.explode(["time", "mag", "magerr", "catflags"], ignore_index=True)
-    ztf_df = ztf_df.astype({"time": "float", "mag": "float", "magerr": "float", "catflags": "int"})
-
-    # remove data flagged as bad
-    ztf_df = ztf_df.loc[ztf_df["catflags"] < 32768, :]
-
-    # calc flux [https://arxiv.org/pdf/1902.01872.pdf zeropoint corrections already applied]
-    mag = ztf_df["mag"].to_numpy()
-    magerr = ztf_df["magerr"].to_numpy()
-    fluxupper = ((mag - magerr) * u.ABmag).to_value('mJy')
-    fluxlower = ((mag + magerr) * u.ABmag).to_value('mJy')
-    ztf_df["flux"] = (mag * u.ABmag).to_value('mJy')
-    ztf_df["err"] = (fluxupper - fluxlower) / 2
-
-    return ztf_df

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.4
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: notebook
   language: python
@@ -74,7 +74,7 @@ This cell will install them if needed:
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-#!pip install -r requirements_light_curve_generator.txt
+!pip install -r requirements_light_curve_generator.txt
 ```
 
 ```{code-cell} ipython3
@@ -101,7 +101,7 @@ from tess_kepler_functions import tess_kepler_get_lightcurves
 from wise_functions import wise_get_lightcurves
 # Note: ZTF data is temporarily located in a non-public AWS S3 bucket. It is automatically available
 # from the Fornax Science Console, but otherwise will require explicit user credentials.
-# from ztf_functions import ztf_get_lightcurves
+from ztf_functions import ztf_get_lightcurves
 ```
 
 ## 1. Define the sample
@@ -226,13 +226,26 @@ The function to retrieve ZTF light curves accesses a parquet version of the ZTF 
 ZTFstarttime = time.time()
 
 # get ZTF lightcurves
-# use the nworkers arg to control the amount of parallelization in the data loading step
-df_lc_ZTF = ztf_get_lightcurves(sample_table, nworkers=6)
+ztf_search_radius = 1.0 #  arcsec
+df_lc_ZTF = ztf_get_lightcurves(sample_table, radius = ztf_search_radius)
 
 # add the resulting dataframe to all other archives
 df_lc.append(df_lc_ZTF)
 
 print('ZTF search took:', time.time() - ZTFstarttime, 's')
+```
+
+```{code-cell} ipython3
+df_lc.data
+```
+
+```{code-cell} ipython3
+import lsdb
+from upath import UPath
+
+ztf_lc = lsdb.read_hats(
+        UPath('s3://irsa-fornax-testdata/ZTF/dr23/lc/hats')).compute()
+ztf_lc['filterid'].head
 ```
 
 ### 2.3 IRSA: WISE

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -367,7 +367,7 @@ For sample sizes >~500 and/or improved logging and monitoring options, consider 
 
 ```{code-cell} ipython3
 # number of workers to use in the parallel processing pool
-# this should equal the total number of archives called
+# this should equal the total number of archives called in the `pool` context below.
 n_workers = 6
 
 # keyword arguments for the archive calls

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -43,7 +43,7 @@ By the end of this tutorial, you will be able to:
  * an archival optical + IR + neutrino light curve
 
 ## Runtime:
-- As of 2025 May, this notebook takes ~1540s (25 min.) to run to completion on Fornax using the ‘Astrophysics Default Image’ and the ‘Large’ server with 16GB RAM/ 4CPU.
+- As of 2025 May, this notebook takes ~1000s (17 min.) to run to completion on Fornax using the ‘Astrophysics Default Image’ and the ‘Large’ server with 64GB RAM/ 16CPU.
 
 ## Authors:
 Jessica Krick, Shoubaneh Hemmati, Andreas Faisst, Troy Raen, Brigitta Sipőcz, David Shupe
@@ -220,7 +220,7 @@ print('heasarc search took:', time.time() - heasarcstarttime, 's')
 ```
 
 ### 2.2 IRSA: ZTF
-The function to retrieve ZTF light curves accesses a [HATS](https://hats.readthedocs.io/en/stable/) parquet version of the ZTF catalog stored in the cloud using [LSDB](https://docs.lsdb.io/en/stable/).  This is the simplest way to access this dataset at scale.  The ZTF [API](https://irsa.ipac.caltech.edu/docs/program_interface/ztf_lightcurve_api.html) is available for small sample searches.  One unique thing about this function is that it has parallelization built in to the function itself because lsdb uses dask under the hood.
+The function to retrieve ZTF light curves accesses a [HATS](https://hats.readthedocs.io/en/stable/) parquet version of the ZTF catalog stored in the cloud using [LSDB](https://docs.lsdb.io/en/stable/). This is the simplest way to access this dataset at scale.  The ZTF [API](https://irsa.ipac.caltech.edu/docs/program_interface/ztf_lightcurve_api.html) is available for small sample searches.  One unique thing about this function is that it has parallelization built in to the function itself because lsdb uses dask under the hood.
 
 Traceback CommClosedErrors are expected and are just a dask houskeeping issue, the function is still running to completion and returning light curves.
 
@@ -258,7 +258,7 @@ print('WISE search took:', time.time() - WISEstarttime, 's')
 ```
 
 ### 2.4 MAST: Pan-STARRS
-The function to retrieve lightcurves from Pan-STARRS uses a version of both the object and light curve catalogs that are stored in the cloud and accessed using [LSDB](https://docs.lsdb.io/en/stable/).  This function is efficient at large scale (sample sizes > ~1000).
+The function to retrieve lightcurves from Pan-STARRS uses [LSDB](https://docs.lsdb.io/) to access versions of the object and light curve catalogs that are stored in the cloud.  This function is efficient at large scale (sample sizes > ~1000).
 
 Some warnings are expected.
 

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -74,7 +74,7 @@ This cell will install them if needed:
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-# !pip install -r requirements_light_curve_generator.txt
+# %pip install -r requirements_light_curve_generator.txt
 ```
 
 ```{code-cell} ipython3

--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -43,7 +43,7 @@ By the end of this tutorial, you will be able to:
  * an archival optical + IR + neutrino light curve
 
 ## Runtime:
-- As of 2025 May, this notebook takes ~1100s (18 min.)to run to completion on Fornax using the ‘Astrophysics Default Image’ and the ‘Large’ server with 16GB RAM/ 4CPU.
+- As of 2025 May, this notebook takes ~1540s (25 min.) to run to completion on Fornax using the ‘Astrophysics Default Image’ and the ‘Large’ server with 16GB RAM/ 4CPU.
 
 ## Authors:
 Jessica Krick, Shoubaneh Hemmati, Andreas Faisst, Troy Raen, Brigitta Sipőcz, David Shupe
@@ -74,7 +74,7 @@ This cell will install them if needed:
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-#!pip install -r requirements_light_curve_generator.txt
+# !pip install -r requirements_light_curve_generator.txt
 ```
 
 ```{code-cell} ipython3
@@ -220,13 +220,15 @@ print('heasarc search took:', time.time() - heasarcstarttime, 's')
 ```
 
 ### 2.2 IRSA: ZTF
-The function to retrieve ZTF light curves accesses a parquet version of the ZTF catalog stored in the cloud using pyarrow.  This is the fastest way to access the ZTF catalog at scale.  The ZTF [API](https://irsa.ipac.caltech.edu/docs/program_interface/ztf_lightcurve_api.html) is available for small sample searches.  One unique thing about this function is that it has parallelization built in to the function itself.
+The function to retrieve ZTF light curves accesses a [HATS](https://hats.readthedocs.io/en/stable/) parquet version of the ZTF catalog stored in the cloud using [LSDB](https://docs.lsdb.io/en/stable/).  This is the simplest way to access this dataset at scale.  The ZTF [API](https://irsa.ipac.caltech.edu/docs/program_interface/ztf_lightcurve_api.html) is available for small sample searches.  One unique thing about this function is that it has parallelization built in to the function itself because lsdb uses dask under the hood.
+
+Traceback CommClosedErrors are expected and are just a dask houskeeping issue, the function is still running to completion and returning light curves.
 
 ```{code-cell} ipython3
 ZTFstarttime = time.time()
 
 # get ZTF lightcurves
-ztf_search_radius = 1.0 #  arcsec
+ztf_search_radius = 1.0 #  arcsec  (Graham et al., 2024 use 1" with good results)
 df_lc_ZTF = ztf_get_lightcurves(sample_table, radius = ztf_search_radius)
 
 # add the resulting dataframe to all other archives
@@ -256,7 +258,7 @@ print('WISE search took:', time.time() - WISEstarttime, 's')
 ```
 
 ### 2.4 MAST: Pan-STARRS
-The function to retrieve lightcurves from Pan-STARRS uses a version of both the object and light curve catalogs that are stored in the cloud and accessed using [lsdb](https://docs.lsdb.io/en/stable/).  This function is efficient at large scale (sample sizes > ~1000).
+The function to retrieve lightcurves from Pan-STARRS uses a version of both the object and light curve catalogs that are stored in the cloud and accessed using [LSDB](https://docs.lsdb.io/en/stable/).  This function is efficient at large scale (sample sizes > ~1000).
 
 Some warnings are expected.
 
@@ -366,7 +368,7 @@ For sample sizes >~500 and/or improved logging and monitoring options, consider 
 ```{code-cell} ipython3
 # number of workers to use in the parallel processing pool
 # this should equal the total number of archives called
-n_workers = 8
+n_workers = 6
 
 # keyword arguments for the archive calls
 heasarc_kwargs = dict(catalog_error_radii={"FERMIGTRIG": "1.0", "SAXGRBMGRB": "3.0"})

--- a/light_curves/requirements_light_curve_generator.txt
+++ b/light_curves/requirements_light_curve_generator.txt
@@ -14,7 +14,7 @@ astroquery>=0.4.8.dev0
 acstools
 lightkurve
 alerce
-lsdb>=0.5.1
+lsdb>=0.5.2
 universal_pathlib
 # We use distributed in this notebook, but installing any dask would make the [dataframe] extras required by dependencies for other notebooks.
 # It feels to be the cleanest solution to add the dependency here as we don't directly use it elsewhere.

--- a/light_curves/requirements_light_curve_generator.txt
+++ b/light_curves/requirements_light_curve_generator.txt
@@ -14,7 +14,7 @@ astroquery>=0.4.8.dev0
 acstools
 lightkurve
 alerce
-lsdb>=0.4.5
+lsdb>=0.5.1
 universal_pathlib
 # We use distributed in this notebook, but installing any dask would make the [dataframe] extras required by dependencies for other notebooks.
 # It feels to be the cleanest solution to add the dependency here as we don't directly use it elsewhere.


### PR DESCRIPTION
Making a generic hat_functions for both ztf and panstarrs is not possible at this point.  There are just too many individualized things that are different between the two different datasets (column names, data types).  Additionally, panstarrs recommends not accessing their light curves catalog directly but going through the object catalog.  For ZTF there is no such recommendation, so that search can happen with just a crossmatch.  All of this lead me to abandon that previous attempt and just make a ztf function to access the new hats files.

This PR will close #409.  I believe I have addressed all of the relevant comments from that PR in this one.  
This PR will close #371 

I did have to touch the wise function to make that work for testing the entire notebook.  There was a permissions issue which is fixed with this PR.

And this time I did check the entire flow of the notebook, and updated the runtime section to reflect that.  The entire runtime did increase from ~800s to ~1100s.  This is an unwelcome time increase when switching to hats file format.  Likely the culprit is that Troy tailored the previous ztf function to optimize runtime, but these hats functions are unfortunately not as speedy out of the box, and likely need to be optimized.  Suggestions from @troyraen on where to look for optimizations are documented in issue #420 
