### PR TITLE
Enable cloud based execution of JWST query

### DIFF
--- a/spectroscopy/code_src/mast_functions.py
+++ b/spectroscopy/code_src/mast_functions.py
@@ -126,14 +126,12 @@ def JWST_get_spec_helper(sample_table, search_radius_arcsec, verbose, max_spectr
         #This code takes a long time if you let it get all spectra, this
         # next part filters out some of the results if not all spectra are needed.
         # change max_spectra_per_source to None if you want all of them
-        if max_spectra_per_source is not None:
+        if max_spectra_per_source is not None and len(data_products_list_filter) > max_spectra_per_source:
             data_products_list_filter = data_products_list_filter[:max_spectra_per_source]
-            #let user know if more data exist but aren't used
-            if len(data_products_list_filter) > max_spectra_per_source:
-                print(f"Limiting to first {max_spectra_per_source} spectra for source {stab['label']}.")
-        
+            print(f"Limiting to first {max_spectra_per_source} spectra for source {stab['label']}.")
+            
         # Get cloud access URIs (returns a list of strings)
-        cloud_uris_map = Observations.get_cloud_uris(data_products_list_filter, return_uri_map=True)
+        cloud_uris_dict = Observations.get_cloud_uris(data_products_list_filter, return_uri_map=True)
 
         # Create table with metadata from data_priducts_list_filter and cloud URIs
         keys = ["filters", "obs_collection", "instrument_name", "calib_level",
@@ -144,7 +142,7 @@ def JWST_get_spec_helper(sample_table, search_radius_arcsec, verbose, max_spectr
         for row in data_products_list_filter:
             filename = str(row["productFilename"])
             lookup_key = f"mast:JWST/product/{filename}"
-            uri = cloud_uris_map.get(lookup_key)
+            uri = cloud_uris_dict.get(lookup_key)
             if uri is None:
                 print(f"Skipping {filename}: not available in cloud.")
                 continue

--- a/spectroscopy/requirements_spectra_generator.txt
+++ b/spectroscopy/requirements_spectra_generator.txt
@@ -7,4 +7,7 @@ pandas
 sparclclient
 astropy
 specutils
-astroquery>=0.4.8
+astroquery>=0.4.11.dev0
+fsspec 
+boto3 
+s3fs

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -262,12 +262,13 @@ df_spec.append(df_spec_HST)
 df_jwst = JWST_get_spec(
     sample_table,
     search_radius_arcsec=0.5,
-    datadir="./data/",
-    verbose=False,
-    delete_downloaded_data=True
+    verbose=False
 )
 df_spec.append(df_jwst)
 ```
+
+JWST spectra are now read directly from cloud storage, so no download
+directory is required.
 
 ### 2.3 ESA Archive
 

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -82,7 +82,7 @@ The ones with an asterisk (*) are the challenging ones.
 ## Runtime
 
 As of 2025 July, this notebook takes about 8 minutes to run to completion on Fornax using
-a server with 8GB RAM/4 CPU' and Environment: 'Default Astrophysics' (image).
+a server with 16GB RAM/4 CPU' and Environment: 'Default Astrophysics' (image).
 
 ## Authors:
 Andreas Faisst, Jessica Krick, Shoubaneh Hemmati, Troy Raen, Brigitta Sipőcz, David Shupe

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -81,8 +81,8 @@ The ones with an asterisk (*) are the challenging ones.
 &bull; ...
 ## Runtime
 
-As of 2024 December, this notebook takes about 17 minutes to run to completion on Fornax using
-Server Type: 'Standard - 8GB RAM/4 CPU' and Environment: 'Default Astrophysics' (image).
+As of 2025 July, this notebook takes about 8 minutes to run to completion on Fornax using
+a server with 8GB RAM/4 CPU' and Environment: 'Default Astrophysics' (image).
 
 ## Authors:
 Andreas Faisst, Jessica Krick, Shoubaneh Hemmati, Troy Raen, Brigitta Sipőcz, David Shupe
@@ -109,20 +109,7 @@ This cell will install them if needed:
 
 ```{code-cell} ipython3
 # Uncomment the next line to install dependencies if needed.
-# !pip install -r requirements_spectra_generator.txt
-# !pip install --upgrade --pre astroquery  # >=0.4.8.dev9474 needed for mast_functions
-```
-
-```{code-cell} ipython3
-%pip install -U --pre astroquery[all]
-```
-
-```{code-cell} ipython3
-%pip install fsspec boto3 
-```
-
-```{code-cell} ipython3
-%pip install s3fs
+# %pip install -r requirements_spectra_generator.txt
 ```
 
 ```{code-cell} ipython3
@@ -138,7 +125,7 @@ from data_structures_spec import MultiIndexDFObject
 #from desi_functions import DESIBOSS_get_spec
 from herschel_functions import Herschel_get_spec
 from keck_functions import KeckDEIMOS_get_spec
-#from mast_functions import HST_get_spec, JWST_get_spec
+from mast_functions import HST_get_spec, JWST_get_spec
 from plot_functions import create_figures
 from sample_selection import clean_sample
 from sdss_functions import SDSS_get_spec
@@ -172,17 +159,17 @@ labels.append("COSMOS1")
 coords.append(SkyCoord(150.1024475, 2.2815559, unit=u.deg))
 labels.append("COSMOS2")
 
-#coords.append(SkyCoord("{} {}".format("150.000", "+2.00"), unit=(u.deg, u.deg)))
-#labels.append("COSMOS3")
+coords.append(SkyCoord("{} {}".format("150.000", "+2.00"), unit=(u.deg, u.deg)))
+labels.append("COSMOS3")
 
-#coords.append(SkyCoord("{} {}".format("+53.15508", "-27.80178"), unit=(u.deg, u.deg)))
-#labels.append("JADESGS-z7-01-QU")
+coords.append(SkyCoord("{} {}".format("+53.15508", "-27.80178"), unit=(u.deg, u.deg)))
+labels.append("JADESGS-z7-01-QU")
 
-#coords.append(SkyCoord("{} {}".format("+53.15398", "-27.80095"), unit=(u.deg, u.deg)))
-#labels.append("TestJWST")
+coords.append(SkyCoord("{} {}".format("+53.15398", "-27.80095"), unit=(u.deg, u.deg)))
+labels.append("TestJWST")
 
-#coords.append(SkyCoord("{} {}".format("+150.33622", "+55.89878"), unit=(u.deg, u.deg)))
-#labels.append("Twin Quasar")
+coords.append(SkyCoord("{} {}".format("+150.33622", "+55.89878"), unit=(u.deg, u.deg)))
+labels.append("Twin Quasar")
 
 sample_table = clean_sample(coords, labels, precision=2.0 * u.arcsecond, verbose=1)
 ```
@@ -270,299 +257,15 @@ df_spec.append(df_spec_HST)
 ```
 
 ```{code-cell} ipython3
-import os
-import shutil
-import warnings
-import fsspec
-
-import astropy.constants as const
-import astropy.units as u
-from astropy.io import fits
-import astroquery.exceptions
-import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
-from astropy.table import Table
-from astropy.table import vstack
-from astroquery.mast import Observations
-from specutils import Spectrum1D
-
-from data_structures_spec import MultiIndexDFObject
-            
-
-def JWST_get_spec(sample_table, search_radius_arcsec, verbose):
-    """
-    Retrieve JWST spectra for a list of sources and groups/stacks them.
-    This main function runs two sub-functions:
-    - `JWST_get_spec_helper()` which searches and retrieves the spectra from
-      the cloud.
-    - `JWST_group_spectra()` which groups and stacks the spectra.
-
-    Parameters
-    ----------
-    sample_table : astropy.table.Table
-        Table with the coordinates and journal reference labels of the sources.
-    search_radius_arcsec : float
-        Search radius in arcseconds.
-    verbose : bool
-        Verbosity level. Set to True for extra talking.
-
-    Returns
-    -------
-    MultiIndexDFObject
-        The spectra returned from the archive.
-    """
-
-    # Get the spectra
-    print("Searching Spectra in the cloud... ")
-    df_jwst_all = JWST_get_spec_helper(
-        sample_table, search_radius_arcsec, verbose)
-    print("done")
-
-    # Group
-    print("Grouping Spectra... ")
-    df_jwst_group = JWST_group_spectra(df_jwst_all, verbose=verbose, quickplot=False)
-    print("done")
-
-    return df_jwst_group
-
-
-def JWST_get_spec_helper(sample_table, search_radius_arcsec, verbose):
-    """
-    Retrieve JWST spectra for a list of sources.
-
-    Parameters
-    ----------
-    sample_table : astropy.table.Table
-        Table with the coordinates and journal reference labels of the sources.
-    search_radius_arcsec : float
-        Search radius in arcseconds.
-    verbose : bool
-        Verbosity level. Set to True for extra talking.
-
-    Returns
-    -------
-    MultiIndexDFObject
-        The spectra returned from the archive.
-    """
-
-    # Enable cloud data access for MAST once
-    Observations.enable_cloud_dataset()
-
-
-    # Initialize multi-index object:
-    df_spec = MultiIndexDFObject()
-
-    for stab in sample_table:
-
-        print("Processing source {}".format(stab["label"]))
-
-        # Query results
-        search_coords = stab["coord"]
-        # If no results are found, this will raise a warning. We explicitly handle the no-results
-        # case below, so let's suppress the warning to avoid confusing notebook users.
-        warnings.filterwarnings("ignore", message='Query returned no results.',
-                                category=astroquery.exceptions.NoResultsWarning,
-                                module="astroquery.mast.discovery_portal")
-        query_results = Observations.query_criteria(
-            coordinates=search_coords, radius=search_radius_arcsec * u.arcsec,
-            dataproduct_type=["spectrum"], obs_collection=["JWST"], intentType="science",
-            calib_level=[2, 3, 4], instrument_name=['NIRSPEC/MSA', 'NIRSPEC/SLIT'],
-            dataRights=['PUBLIC'])
-        print("Number of search results: {}".format(len(query_results)))
-
-        if len(query_results) == 0:
-            print("Source {} could not be found".format(stab["label"]))
-            continue
-
-        # Retrieve spectra
-        data_products = [Observations.get_product_list(obs) for obs in query_results]
-        data_products_list = vstack(data_products)
-        
-        # Filter
-        data_products_list_filter = Observations.filter_products(
-            data_products_list, productType=["SCIENCE"], extension="fits",
-            calib_level=[2, 3, 4],  # only calibrated data
-            productSubGroupDescription=["X1D"],  # only 1D spectra
-            dataRights=['PUBLIC'])  # only public data
-        print("Number of files found: {}".format(len(data_products_list_filter)))
-
-        if len(data_products_list_filter) == 0:
-            print("No spectra found for source {}.".format(stab["label"]))
-            continue
-
-        # Get cloud access URIs (returns a list of strings)
-        cloud_uris_map = Observations.get_cloud_uris(data_products_list_filter, return_uri_map=True)
-
-        # Create table with metadata from data_priducts_list_filter and cloud URIs
-        keys = ["filters", "obs_collection", "instrument_name", "calib_level",
-                "t_obs_release", "proposal_id", "obsid", "objID", "distance"]
-        tab = Table(names=keys + ["productFilename", "clouduri"],
-                    dtype=[str, str, str, int, float, int, int, int, float, str, str])
-
-        for row in data_products_list_filter:
-            filename = str(row["productFilename"])
-            lookup_key = f"mast:JWST/product/{filename}"
-            uri = cloud_uris_map.get(lookup_key)
-            if uri is None:
-                print(f"Skipping {filename}: not available in cloud.")
-                continue
-
-            obsid = row["parent_obsid"]
-            idx_cross = np.where(query_results["obsid"] == obsid)[0]
-
-            tmp = query_results[idx_cross][keys]
-            tab.add_row(list(tmp[0]) + [filename, uri])
-
-            
-        # Create multi-index object
-        for jj in range(len(tab)):
-
-            # open spectrum directly from the cloud
-            filepath = tab["clouduri"][jj]
-            
-            with fsspec.open(filepath, mode='rb', anon=True) as f:  # Open the file from S3
-                with fits.open(f) as hdul:  # Open the FITS file
-                    spec1d = Table(hdul[1].data)
-                    columns = hdul[1].columns
-                    print("flux: ", spec1d["FLUX"].data)
-                    # Explicitly extract units
-                    wave_unit = u.Unit(getattr(columns["WAVELENGTH"], 'unit', None))
-                    flux_unit = u.Unit(getattr(columns["FLUX"], 'unit', None))
-                    err_unit = u.Unit(getattr(columns["FLUX_ERROR"], 'unit', None))
-
-            dfsingle = pd.DataFrame(dict(
-                wave=[spec1d["WAVELENGTH"].data * wave_unit],
-                flux=[spec1d["FLUX"].data * flux_unit],
-                err=[spec1d["FLUX_ERROR"].data * err_unit],
-                label=[stab["label"]],
-                objectid=[stab["objectid"]],
-                mission=[tab["obs_collection"][jj]],
-                instrument=[tab["instrument_name"][jj]],
-                filter=[tab["filters"][jj]],
-            )).set_index(["objectid", "label", "filter", "mission"])
-            df_spec.append(dfsingle)
-
-
-    return df_spec
-
-
-def JWST_group_spectra(df, verbose, quickplot):
-    """
-    Group the JWST spectra and removes entries that have no spectra.
-    Stack spectra that are similar and create a new DataFrame.
-
-    Parameters
-    ----------
-    df : MultiIndexDFObject
-        Raw JWST multi-index object (output from JWST_get_spec()).
-    verbose : bool
-        Flag for verbosity: True or False.
-    quickplot : bool
-        If True, quick plots are made for each spectral group.
-
-    Returns
-    -------
-    MultiIndexDFObject
-        Consolidated and grouped data structure storing the spectra.
-    """
-
-    # Initialize multi-index object:
-    df_spec = MultiIndexDFObject()
-
-    # Create data table from DF.
-    tab = df.data.reset_index()
-
-    # Get objects
-    objects_unique = np.unique(tab["label"])
-
-    for obj in objects_unique:
-        print("Grouping object {}".format(obj))
-
-        # Get filters
-        filters_unique = np.unique(tab["filter"])
-        if verbose:
-            print("List of filters in data frame: {}".format(" | ".join(filters_unique)))
-
-        for filt in filters_unique:
-            if verbose:
-                print("Processing {}: ".format(filt), end=" ")
-
-            sel = np.where((tab["filter"] == filt) & (tab["label"] == obj))[0]
-            tab_sel = tab.iloc[sel]
-            if verbose:
-                print("Number of items: {}".format(len(sel)), end=" | ")
-
-            # get good ones
-            sum_flux = np.asarray(
-                [np.nansum(tab_sel.iloc[iii]["flux"]).value for iii in range(len(tab_sel))])
-            idx_good = np.where(sum_flux > 0)[0]
-            if verbose:
-                print("Number of good spectra: {}".format(len(idx_good)))
-
-            if len(idx_good) == 0:
-                continue
-
-            # Create wavelength grid
-            wave_grid = tab_sel.iloc[idx_good[0]]["wave"]  # NEED TO BE MADE BETTER LATER
-
-            # Interpolate fluxes
-            fluxes_int = np.asarray(
-                [np.interp(wave_grid, tab_sel.iloc[idx]["wave"], tab_sel.iloc[idx]["flux"]) for idx in idx_good])
-            fluxes_units = [tab_sel.iloc[idx]["flux"].unit for idx in idx_good]
-
-            # Sometimes fluxes are all NaN. We'll leave these in and ignore the RuntimeWarning.
-            warnings.filterwarnings("ignore", message='All-NaN slice encountered', category=RuntimeWarning)
-            fluxes_stack = np.nanmedian(fluxes_int, axis=0)
-            if verbose:
-                print("Units of fluxes for each spectrum: {}".format(
-                    ",".join([str(tt) for tt in fluxes_units])))
-
-            # Unit conversion to erg/s/cm2/A
-            # (note fluxes are nominally in Jy. So have to do the step with dividing by lam^2)
-            fluxes_stack_cgs = (fluxes_stack * fluxes_units[0]).to(u.erg / u.second / (
-                u.centimeter**2) / u.hertz) * (const.c.to(u.angstrom/u.second)) / (wave_grid.to(u.angstrom)**2)
-            fluxes_stack_cgs = fluxes_stack_cgs.to(
-                u.erg / u.second / (u.centimeter**2) / u.angstrom)
-
-            # Add to data frame
-            dfsingle = pd.DataFrame(dict(
-                wave=[wave_grid.to(u.micrometer)], flux=[fluxes_stack_cgs],
-                err=[np.repeat(0, len(fluxes_stack_cgs))], label=[tab_sel["label"].iloc[0]],
-                objectid=[tab_sel["objectid"].iloc[0]], mission=[tab_sel["mission"].iloc[0]],
-                instrument=[tab_sel["instrument"].iloc[0]], filter=[tab_sel["filter"].iloc[0]]))
-            dfsingle = dfsingle.set_index(["objectid", "label", "filter", "mission"])
-            df_spec.append(dfsingle)
-
-            # Quick plot
-            if quickplot:
-                tmp = np.percentile(fluxes_stack, q=(1, 50, 99))
-                plt.plot(wave_grid, fluxes_stack)
-                plt.ylim(tmp[0], tmp[2])
-                plt.xlabel(r"Observed Wavelength [$\mu$m]")
-                plt.ylabel(r"Flux [Jy]")
-                plt.show()
-
-    return df_spec
-```
-
-```{code-cell} ipython3
 %%time
 # Get Spectra for JWST
 df_jwst = JWST_get_spec(
     sample_table,
     search_radius_arcsec=0.5,
-    verbose=False
+    verbose=False,
+    max_spectra_per_source = 5
 )
 df_spec.append(df_jwst)
-```
-
-```{code-cell} ipython3
-df_jwst.data
-```
-
-```{code-cell} ipython3
-
 ```
 
 ### 2.3 ESA Archive

--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -4,11 +4,11 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.7
+    jupytext_version: 1.17.2
 kernelspec:
-  display_name: notebook
+  name: py-spectra_generator
+  display_name: py-spectra_generator
   language: python
-  name: python3
 ---
 
 # Extract Multi-Wavelength Spectroscopy from Archival Data
@@ -88,7 +88,8 @@ Server Type: 'Standard - 8GB RAM/4 CPU' and Environment: 'Default Astrophysics' 
 Andreas Faisst, Jessica Krick, Shoubaneh Hemmati, Troy Raen, Brigitta Sipőcz, David Shupe
 
 ## Acknowledgements:
-...
+
+AI: This notebook was created with assistance from OpenAI’s ChatGPT o4-mini-high model.
 
 +++
 
@@ -113,6 +114,18 @@ This cell will install them if needed:
 ```
 
 ```{code-cell} ipython3
+%pip install -U --pre astroquery[all]
+```
+
+```{code-cell} ipython3
+%pip install fsspec boto3 
+```
+
+```{code-cell} ipython3
+%pip install s3fs
+```
+
+```{code-cell} ipython3
 import os
 import sys
 
@@ -122,10 +135,10 @@ from astropy.table import Table
 
 sys.path.append('code_src/')
 from data_structures_spec import MultiIndexDFObject
-from desi_functions import DESIBOSS_get_spec
+#from desi_functions import DESIBOSS_get_spec
 from herschel_functions import Herschel_get_spec
 from keck_functions import KeckDEIMOS_get_spec
-from mast_functions import HST_get_spec, JWST_get_spec
+#from mast_functions import HST_get_spec, JWST_get_spec
 from plot_functions import create_figures
 from sample_selection import clean_sample
 from sdss_functions import SDSS_get_spec
@@ -159,17 +172,17 @@ labels.append("COSMOS1")
 coords.append(SkyCoord(150.1024475, 2.2815559, unit=u.deg))
 labels.append("COSMOS2")
 
-coords.append(SkyCoord("{} {}".format("150.000", "+2.00"), unit=(u.deg, u.deg)))
-labels.append("COSMOS3")
+#coords.append(SkyCoord("{} {}".format("150.000", "+2.00"), unit=(u.deg, u.deg)))
+#labels.append("COSMOS3")
 
-coords.append(SkyCoord("{} {}".format("+53.15508", "-27.80178"), unit=(u.deg, u.deg)))
-labels.append("JADESGS-z7-01-QU")
+#coords.append(SkyCoord("{} {}".format("+53.15508", "-27.80178"), unit=(u.deg, u.deg)))
+#labels.append("JADESGS-z7-01-QU")
 
-coords.append(SkyCoord("{} {}".format("+53.15398", "-27.80095"), unit=(u.deg, u.deg)))
-labels.append("TestJWST")
+#coords.append(SkyCoord("{} {}".format("+53.15398", "-27.80095"), unit=(u.deg, u.deg)))
+#labels.append("TestJWST")
 
-coords.append(SkyCoord("{} {}".format("+150.33622", "+55.89878"), unit=(u.deg, u.deg)))
-labels.append("Twin Quasar")
+#coords.append(SkyCoord("{} {}".format("+150.33622", "+55.89878"), unit=(u.deg, u.deg)))
+#labels.append("Twin Quasar")
 
 sample_table = clean_sample(coords, labels, precision=2.0 * u.arcsecond, verbose=1)
 ```
@@ -257,6 +270,283 @@ df_spec.append(df_spec_HST)
 ```
 
 ```{code-cell} ipython3
+import os
+import shutil
+import warnings
+import fsspec
+
+import astropy.constants as const
+import astropy.units as u
+from astropy.io import fits
+import astroquery.exceptions
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from astropy.table import Table
+from astropy.table import vstack
+from astroquery.mast import Observations
+from specutils import Spectrum1D
+
+from data_structures_spec import MultiIndexDFObject
+            
+
+def JWST_get_spec(sample_table, search_radius_arcsec, verbose):
+    """
+    Retrieve JWST spectra for a list of sources and groups/stacks them.
+    This main function runs two sub-functions:
+    - `JWST_get_spec_helper()` which searches and retrieves the spectra from
+      the cloud.
+    - `JWST_group_spectra()` which groups and stacks the spectra.
+
+    Parameters
+    ----------
+    sample_table : astropy.table.Table
+        Table with the coordinates and journal reference labels of the sources.
+    search_radius_arcsec : float
+        Search radius in arcseconds.
+    verbose : bool
+        Verbosity level. Set to True for extra talking.
+
+    Returns
+    -------
+    MultiIndexDFObject
+        The spectra returned from the archive.
+    """
+
+    # Get the spectra
+    print("Searching Spectra in the cloud... ")
+    df_jwst_all = JWST_get_spec_helper(
+        sample_table, search_radius_arcsec, verbose)
+    print("done")
+
+    # Group
+    print("Grouping Spectra... ")
+    df_jwst_group = JWST_group_spectra(df_jwst_all, verbose=verbose, quickplot=False)
+    print("done")
+
+    return df_jwst_group
+
+
+def JWST_get_spec_helper(sample_table, search_radius_arcsec, verbose):
+    """
+    Retrieve JWST spectra for a list of sources.
+
+    Parameters
+    ----------
+    sample_table : astropy.table.Table
+        Table with the coordinates and journal reference labels of the sources.
+    search_radius_arcsec : float
+        Search radius in arcseconds.
+    verbose : bool
+        Verbosity level. Set to True for extra talking.
+
+    Returns
+    -------
+    MultiIndexDFObject
+        The spectra returned from the archive.
+    """
+
+    # Enable cloud data access for MAST once
+    Observations.enable_cloud_dataset()
+
+
+    # Initialize multi-index object:
+    df_spec = MultiIndexDFObject()
+
+    for stab in sample_table:
+
+        print("Processing source {}".format(stab["label"]))
+
+        # Query results
+        search_coords = stab["coord"]
+        # If no results are found, this will raise a warning. We explicitly handle the no-results
+        # case below, so let's suppress the warning to avoid confusing notebook users.
+        warnings.filterwarnings("ignore", message='Query returned no results.',
+                                category=astroquery.exceptions.NoResultsWarning,
+                                module="astroquery.mast.discovery_portal")
+        query_results = Observations.query_criteria(
+            coordinates=search_coords, radius=search_radius_arcsec * u.arcsec,
+            dataproduct_type=["spectrum"], obs_collection=["JWST"], intentType="science",
+            calib_level=[2, 3, 4], instrument_name=['NIRSPEC/MSA', 'NIRSPEC/SLIT'],
+            dataRights=['PUBLIC'])
+        print("Number of search results: {}".format(len(query_results)))
+
+        if len(query_results) == 0:
+            print("Source {} could not be found".format(stab["label"]))
+            continue
+
+        # Retrieve spectra
+        data_products = [Observations.get_product_list(obs) for obs in query_results]
+        data_products_list = vstack(data_products)
+        
+        # Filter
+        data_products_list_filter = Observations.filter_products(
+            data_products_list, productType=["SCIENCE"], extension="fits",
+            calib_level=[2, 3, 4],  # only calibrated data
+            productSubGroupDescription=["X1D"],  # only 1D spectra
+            dataRights=['PUBLIC'])  # only public data
+        print("Number of files found: {}".format(len(data_products_list_filter)))
+
+        if len(data_products_list_filter) == 0:
+            print("No spectra found for source {}.".format(stab["label"]))
+            continue
+
+        # Get cloud access URIs (returns a list of strings)
+        cloud_uris_map = Observations.get_cloud_uris(data_products_list_filter, return_uri_map=True)
+
+        # Create table with metadata from data_priducts_list_filter and cloud URIs
+        keys = ["filters", "obs_collection", "instrument_name", "calib_level",
+                "t_obs_release", "proposal_id", "obsid", "objID", "distance"]
+        tab = Table(names=keys + ["productFilename", "clouduri"],
+                    dtype=[str, str, str, int, float, int, int, int, float, str, str])
+
+        for row in data_products_list_filter:
+            filename = str(row["productFilename"])
+            lookup_key = f"mast:JWST/product/{filename}"
+            uri = cloud_uris_map.get(lookup_key)
+            if uri is None:
+                print(f"Skipping {filename}: not available in cloud.")
+                continue
+
+            obsid = row["parent_obsid"]
+            idx_cross = np.where(query_results["obsid"] == obsid)[0]
+
+            tmp = query_results[idx_cross][keys]
+            tab.add_row(list(tmp[0]) + [filename, uri])
+
+            
+        # Create multi-index object
+        for jj in range(len(tab)):
+
+            # open spectrum directly from the cloud
+            filepath = tab["clouduri"][jj]
+            
+            with fsspec.open(filepath, mode='rb', anon=True) as f:  # Open the file from S3
+                with fits.open(f) as hdul:  # Open the FITS file
+                    spec1d = Table(hdul[1].data)
+                    columns = hdul[1].columns
+                    print("flux: ", spec1d["FLUX"].data)
+                    # Explicitly extract units
+                    wave_unit = u.Unit(getattr(columns["WAVELENGTH"], 'unit', None))
+                    flux_unit = u.Unit(getattr(columns["FLUX"], 'unit', None))
+                    err_unit = u.Unit(getattr(columns["FLUX_ERROR"], 'unit', None))
+
+            dfsingle = pd.DataFrame(dict(
+                wave=[spec1d["WAVELENGTH"].data * wave_unit],
+                flux=[spec1d["FLUX"].data * flux_unit],
+                err=[spec1d["FLUX_ERROR"].data * err_unit],
+                label=[stab["label"]],
+                objectid=[stab["objectid"]],
+                mission=[tab["obs_collection"][jj]],
+                instrument=[tab["instrument_name"][jj]],
+                filter=[tab["filters"][jj]],
+            )).set_index(["objectid", "label", "filter", "mission"])
+            df_spec.append(dfsingle)
+
+
+    return df_spec
+
+
+def JWST_group_spectra(df, verbose, quickplot):
+    """
+    Group the JWST spectra and removes entries that have no spectra.
+    Stack spectra that are similar and create a new DataFrame.
+
+    Parameters
+    ----------
+    df : MultiIndexDFObject
+        Raw JWST multi-index object (output from JWST_get_spec()).
+    verbose : bool
+        Flag for verbosity: True or False.
+    quickplot : bool
+        If True, quick plots are made for each spectral group.
+
+    Returns
+    -------
+    MultiIndexDFObject
+        Consolidated and grouped data structure storing the spectra.
+    """
+
+    # Initialize multi-index object:
+    df_spec = MultiIndexDFObject()
+
+    # Create data table from DF.
+    tab = df.data.reset_index()
+
+    # Get objects
+    objects_unique = np.unique(tab["label"])
+
+    for obj in objects_unique:
+        print("Grouping object {}".format(obj))
+
+        # Get filters
+        filters_unique = np.unique(tab["filter"])
+        if verbose:
+            print("List of filters in data frame: {}".format(" | ".join(filters_unique)))
+
+        for filt in filters_unique:
+            if verbose:
+                print("Processing {}: ".format(filt), end=" ")
+
+            sel = np.where((tab["filter"] == filt) & (tab["label"] == obj))[0]
+            tab_sel = tab.iloc[sel]
+            if verbose:
+                print("Number of items: {}".format(len(sel)), end=" | ")
+
+            # get good ones
+            sum_flux = np.asarray(
+                [np.nansum(tab_sel.iloc[iii]["flux"]).value for iii in range(len(tab_sel))])
+            idx_good = np.where(sum_flux > 0)[0]
+            if verbose:
+                print("Number of good spectra: {}".format(len(idx_good)))
+
+            if len(idx_good) == 0:
+                continue
+
+            # Create wavelength grid
+            wave_grid = tab_sel.iloc[idx_good[0]]["wave"]  # NEED TO BE MADE BETTER LATER
+
+            # Interpolate fluxes
+            fluxes_int = np.asarray(
+                [np.interp(wave_grid, tab_sel.iloc[idx]["wave"], tab_sel.iloc[idx]["flux"]) for idx in idx_good])
+            fluxes_units = [tab_sel.iloc[idx]["flux"].unit for idx in idx_good]
+
+            # Sometimes fluxes are all NaN. We'll leave these in and ignore the RuntimeWarning.
+            warnings.filterwarnings("ignore", message='All-NaN slice encountered', category=RuntimeWarning)
+            fluxes_stack = np.nanmedian(fluxes_int, axis=0)
+            if verbose:
+                print("Units of fluxes for each spectrum: {}".format(
+                    ",".join([str(tt) for tt in fluxes_units])))
+
+            # Unit conversion to erg/s/cm2/A
+            # (note fluxes are nominally in Jy. So have to do the step with dividing by lam^2)
+            fluxes_stack_cgs = (fluxes_stack * fluxes_units[0]).to(u.erg / u.second / (
+                u.centimeter**2) / u.hertz) * (const.c.to(u.angstrom/u.second)) / (wave_grid.to(u.angstrom)**2)
+            fluxes_stack_cgs = fluxes_stack_cgs.to(
+                u.erg / u.second / (u.centimeter**2) / u.angstrom)
+
+            # Add to data frame
+            dfsingle = pd.DataFrame(dict(
+                wave=[wave_grid.to(u.micrometer)], flux=[fluxes_stack_cgs],
+                err=[np.repeat(0, len(fluxes_stack_cgs))], label=[tab_sel["label"].iloc[0]],
+                objectid=[tab_sel["objectid"].iloc[0]], mission=[tab_sel["mission"].iloc[0]],
+                instrument=[tab_sel["instrument"].iloc[0]], filter=[tab_sel["filter"].iloc[0]]))
+            dfsingle = dfsingle.set_index(["objectid", "label", "filter", "mission"])
+            df_spec.append(dfsingle)
+
+            # Quick plot
+            if quickplot:
+                tmp = np.percentile(fluxes_stack, q=(1, 50, 99))
+                plt.plot(wave_grid, fluxes_stack)
+                plt.ylim(tmp[0], tmp[2])
+                plt.xlabel(r"Observed Wavelength [$\mu$m]")
+                plt.ylabel(r"Flux [Jy]")
+                plt.show()
+
+    return df_spec
+```
+
+```{code-cell} ipython3
 %%time
 # Get Spectra for JWST
 df_jwst = JWST_get_spec(
@@ -267,8 +557,13 @@ df_jwst = JWST_get_spec(
 df_spec.append(df_jwst)
 ```
 
-JWST spectra are now read directly from cloud storage, so no download
-directory is required.
+```{code-cell} ipython3
+df_jwst.data
+```
+
+```{code-cell} ipython3
+
+```
 
 ### 2.3 ESA Archive
 


### PR DESCRIPTION
The big changes here from main are:
- enabling cloud-based execution of the JWST query 
- adding relevant documentation
- optionally reducing the total number of spectra that are looked at.

The problem I was trying to address was that the JWST query was too slow to run at even small scales (few hundreds or thousands).  This PR replaces #429 which attempted to speedup the JWST query using MastMissions class in astroquery.  This is a functional route, but not faster than using Observations.  In the end we decided to use the cloud URI functionality in the observations class to speed up this query by not actually downloading the data but instead accessing the cloud versions of the spectra.  The second speedup comes from an optional parameter to only look at a maximum requested number of spectra.  So, if JWST has a few hundred spectra of a single source, this function will now allow the user to select to look at only a subset.  Users wanting to spend the time to get all the data can choose to do so, but for the purposes of a demo notebook, I am currently limiting the function to 5 spectra per source.
