### PR TITLE
changed to specutils.Spectrum instead of Spectrum1D

### DIFF
--- a/spectroscopy/code_src/mast_functions.py
+++ b/spectroscopy/code_src/mast_functions.py
@@ -13,7 +13,7 @@ import pandas as pd
 from astropy.table import Table
 from astropy.table import vstack
 from astroquery.mast import Observations
-from specutils import Spectrum1D
+from specutils import Spectrum
 
 from data_structures_spec import MultiIndexDFObject
 
@@ -379,7 +379,7 @@ def HST_get_spec(sample_table, search_radius_arcsec, datadir, verbose,
 
             # open spectrum
             filepath = download_results["Local Path"][file_idx[0]]
-            spec1d = Spectrum1D.read(filepath)
+            spec1d = Spectrum.read(filepath)
 
             # Note: this should be in erg/s/cm2/A and any wavelength unit.
             dfsingle = pd.DataFrame(dict(

--- a/spectroscopy/requirements_spectra_generator.txt
+++ b/spectroscopy/requirements_spectra_generator.txt
@@ -6,8 +6,10 @@ matplotlib
 pandas
 sparclclient
 astropy
-specutils
+# due to Spectrum1D rename to Spectrum
+specutils>=1.20
+# due to astroquery.mast fixes
 astroquery>=0.4.11.dev0
-fsspec 
-boto3 
+fsspec
+boto3
 s3fs


### PR DESCRIPTION
fixing #436 deprecation warning by switching from Spectrum to Spectrum1D.  Appears to have no downstream effects and doesn't effect the runtime. 

This will close #436 