### PR TITLE
MAINT: removing rendering FSC documentation here

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -40,11 +40,8 @@ exclude_patterns = ['_build', 'notes', '.tox', '.tmp', '.pytest_cache']
 # the data and output directories that are to be populated while running the notebooks.
 exclude_patterns += ['README.md', '*/data/*', '*/output/*']
 
-# We exclude the documentation index.md as its sole purpose is for their CI.
-exclude_patterns += ['documentation/index.md',]
-
 # Not yet included in the rendering:
-exclude_patterns += ['documentation/notebook_review_process.md', 'spectroscopy/*', '*/code_src/*']
+exclude_patterns += ['spectroscopy/*', '*/code_src/*']
 
 # Myst-NB configuration
 # Override kernelspec.name for rendering for all the notebooks.

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ allowlist_externals =
 commands =
     pip freeze
 
-    buildhtml: bash -c 'if [[ ! -d documentation ]]; then git clone --depth 1 https://github.com/nasa-fornax/fornax-documentation.git documentation; else cd documentation; git fetch --all; git pull; cd ..; fi'
     buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=auto -nWT --keep-going
     # SED magic to remove the toctree captions from the rendered index page while keeping them in the sidebar TOC
     buildhtml: sed -E -i.bak '/caption-text/{N; s/.+caption-text.+\n<ul>/<ul>/; P;D;}' _build/html/index.html


### PR DESCRIPTION
This should fix #451 also closes https://github.com/nasa-fornax/fornax-demo-notebooks/issues/425