### PR TITLE
Comment out heasarc_get_lightcurves() to temporarily patch #457

### DIFF
--- a/light_curves/light_curve_generator.md
+++ b/light_curves/light_curve_generator.md
@@ -198,24 +198,27 @@ The function to retrieve HEASARC data accesses the HEASARC archive using a pyvo 
 While these aren't strictly light curves, we would like to track if there are gamma rays detected in advance of any change in the CLAGN light curves. We store these gamma ray detections as single data points.  Because gamma ray detections typically have very large error radii, our current technique is to keep matches in the catalogs within some manually selected error radius, currently defaulting to 1 degree for Fermi and 3 degrees for Beppo SAX.  These values are chosen based on a histogram of all values for those catalogs.
 
 ```{code-cell} ipython3
-start_serial = time.time()  #keep track of all serial archive calls to compare later with parallel archive call time
-heasarcstarttime = time.time()
+# This data is temporarily unavailable.
+# This cell will be uncommented once the data is available again.
 
-# What is the size of error_radius for the catalogs that we will accept for our cross-matching?
-# in degrees; chosen based on histogram of all values for these catalogs
-max_fermi_error_radius = str(1.0)
-max_sax_error_radius = str(3.0)
-
-# catalogs to query and their corresponding max error radii
-heasarc_catalogs = {"FERMIGTRIG": max_fermi_error_radius, "SAXGRBMGRB": max_sax_error_radius}
-
-# get heasarc light curves in the above curated list of catalogs
-df_lc_HEASARC = heasarc_get_lightcurves(sample_table, catalog_error_radii=heasarc_catalogs)
-
-# add the resulting dataframe to all other archives
-df_lc.append(df_lc_HEASARC)
-
-print('heasarc search took:', time.time() - heasarcstarttime, 's')
+# start_serial = time.time()  #keep track of all serial archive calls to compare later with parallel archive call time
+# heasarcstarttime = time.time()
+#
+# # What is the size of error_radius for the catalogs that we will accept for our cross-matching?
+# # in degrees; chosen based on histogram of all values for these catalogs
+# max_fermi_error_radius = str(1.0)
+# max_sax_error_radius = str(3.0)
+#
+# # catalogs to query and their corresponding max error radii
+# heasarc_catalogs = {"FERMIGTRIG": max_fermi_error_radius, "SAXGRBMGRB": max_sax_error_radius}
+#
+# # get heasarc light curves in the above curated list of catalogs
+# df_lc_HEASARC = heasarc_get_lightcurves(sample_table, catalog_error_radii=heasarc_catalogs)
+#
+# # add the resulting dataframe to all other archives
+# df_lc.append(df_lc_HEASARC)
+#
+# print('heasarc search took:', time.time() - heasarcstarttime, 's')
 ```
 
 ### 2.2 IRSA: WISE
@@ -417,7 +420,7 @@ callback = parallel_df_lc.append  # will be called once on the result returned b
 with mp.Pool(processes=n_workers) as pool:
 
     # start the processes that call the archives
-    pool.apply_async(heasarc_get_lightcurves, args=(sample_table,), kwds=heasarc_kwargs, callback=callback)
+    # pool.apply_async(heasarc_get_lightcurves, args=(sample_table,), kwds=heasarc_kwargs, callback=callback)
     pool.apply_async(wise_get_lightcurves, args=(sample_table,), kwds=wise_kwargs, callback=callback)
     pool.apply_async(tess_kepler_get_lightcurves, args=(sample_table,), kwds=tess_kepler_kwargs, callback=callback)
     pool.apply_async(hcv_get_lightcurves, args=(sample_table,), kwds=hcv_kwargs, callback=callback)


### PR DESCRIPTION
This notebook has been crashing for at least three weeks due to #457. This PR adds a note to the HEASARC section stating that the data is temporarily unavailable and comments out the `heasarc_get_lightcurves()` function so that the rest of the notebook will run. If this PR goes through, I'll add a sub-issue to #457 to remind us to fully revert it once the bug is fixed (the serial cell will be obvious but the parallel cell will be easy to forget).