### PR TITLE
Update docs link and cloud languaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo houses tutorial notebooks of fully worked science use cases for all us
 
 ## Documentation
 
-The user cases and documentation of the Fornax Initiative are currently available at the https://nasa-fornax.github.io/fornax-documentation/ URL, while the source code for the documentation can be found in the [fornax-documentation](https://github.com/nasa-fornax/fornax-documentation) repository.
+The documentation of the Fornax Initiative are currently available at the https://nasa-fornax.github.io/fornax-documentation/ URL, while the source code for the documentation can be found in the [fornax-documentation](https://github.com/nasa-fornax/fornax-documentation) repository.
 
 ## Content contributing
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 The Fornax Initiative is a NASA Astrophysics Archives project to collaboratively among the three archives HEASARC, IRSA, and MAST, create cloud systems, cloud software, and cloud standards for the astronomical community.
 
-The Fornax Science Console is a cloud compute system near to NASA data in the AWS cloud which provides a place where astronomers can do data-intensive research with reduced barriers. The Fornax Initiative provides increased compute, increased memory, increased ease of use by pre-installing astronomical software, increased reproducibility of big data results, and increased inclusion by removing some of these barriers to entry, tutorial notebooks, and documentation.
+The Fornax Science Console is a cloud compute system near to NASA data on the AWS cloud which provides a place where astronomers can do data-intensive research with reduced barriers. The Fornax Initiative provides increased compute, increased memory, increased ease of use by pre-installing astronomical software, increased reproducibility of big data results, and increased inclusion by removing some of these barriers to entry, tutorial notebooks, and documentation.
 
 This repo houses tutorial notebooks of fully worked science use cases for all users.  Common goals of the notebooks are the usage of archival data from all NASA archives, cross-archive work, big data, and computationally intensive science. Currently, there are two major topics for which we have notebooks.  The "Photometry" notebook starts with a catalog and a set of archival images.  The notebook grabs all necessary images and measures photometry at all positions listed in the catalog on all images.  The "Time Domain" notebooks are twofold.  The first generates light curves from all available archival data for any user-supplied sample of targets.  The second notebook runs ML algorithms to classify those generated light curves.
 
 
 ## Documentation
 
-The user cases and documentation of the Fornax Initiative are currently available at the https://nasa-fornax.github.io/fornax-demo-notebooks/ URL, while the source code for the documentation can be found in the [fornax-documentation](https://github.com/nasa-fornax/fornax-documentation) repository.
+The user cases and documentation of the Fornax Initiative are currently available at the https://nasa-fornax.github.io/fornax-documentation/ URL, while the source code for the documentation can be found in the [fornax-documentation](https://github.com/nasa-fornax/fornax-documentation) repository.
 
 ## Content contributing
 


### PR DESCRIPTION
- Update the link to rendered fornax-documentation since the docs and notebooks were separated.
- Change "in" -> "on" to comply with the [AWS Onboarding Handbook](https://assets.opendata.aws/aws-onboarding-handbook-for-data-providers-en-US.pdf) where page 18 says:

> Lastly, make sure it does not sound like your data is available “in” AWS. It is more appropriate
to reference that it is available “on” AWS.