### PR TITLE
Add external links to index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,8 +1,9 @@
 # The Fornax Initiative
 
-NASA Astrophysics is developing the Fornax Initiative, a cloud-based system that
+NASA Astrophysics is developing the [Fornax Initiative](https://pcos.gsfc.nasa.gov/Fornax/), a cloud-based system that
 brings together data, software, and computing so that researchers can focus on science.
 
+[Fornax Science Console](https://science-console.fornax.sciencecloud.nasa.gov/) | [Documentation](https://nasa-fornax.github.io/fornax-documentation/) | [Fornax Community Forum](https://discourse.fornax.sciencecloud.nasa.gov/)
 
 ## Tutorial Notebooks
 


### PR DESCRIPTION
Closes #479 

The way @vandesai1 put the links onto this banner is exactly what I was trying to describe wanting to do for this repo on Wednesday. All on the same line, separated by pipes, and right underneath the title and mission statement.

<img width="762" height="138" alt="Screenshot 2025-08-22 at 12 09 16 AM" src="https://github.com/user-attachments/assets/f2a56b3c-ca19-468e-8edd-17b0c93d1d54" />

That's how I've added it here, at least for starters. The thing I can't do here is to center them, but since the title on this index page isn't centered either maybe left-justified will look better anyway. I can't build these docs locally right now but curious to see how it looks. Can always change it if it doesn't look good.