### PR TITLE
Bump lsdb version

### DIFF
--- a/crossmatch/requirements_ztf_ps1_crossmatch.txt
+++ b/crossmatch/requirements_ztf_ps1_crossmatch.txt
@@ -1,5 +1,6 @@
 astropy
 pandas
 matplotlib
-lsdb[full]>=0.6.0  # [full] needed for s3fs
+# [full] needed for s3fs. >=0.6.2 for improved s3 read speed.
+lsdb[full]>=0.6.2
 dask

--- a/light_curves/requirements_light_curve_collector.txt
+++ b/light_curves/requirements_light_curve_collector.txt
@@ -14,7 +14,8 @@ astroquery>=0.4.8.dev0
 acstools
 lightkurve
 alerce
-lsdb>=0.5.2
+# [full] needed for s3fs. >=0.6.2 for improved s3 read speed.
+lsdb[full]>=0.6.2
 universal_pathlib
 # We use distributed in this notebook, but installing any dask would make the [dataframe] extras required by dependencies for other notebooks.
 # It feels to be the cleanest solution to add the dependency here as we don't directly use it elsewhere.


### PR DESCRIPTION
`lsdb` made significant improvements to their S3 read speed, so it would be good to upgrade if we can. This is not strictly necessary. Fine to close if problematic (though I think light_curve_collector will need to be bumped to 0.6.0 at least).