### PR TITLE
Fix ZTF time min/max for plotting

### DIFF
--- a/light_curves/code_src/plot_functions.py
+++ b/light_curves/code_src/plot_functions.py
@@ -67,17 +67,12 @@ def create_figures(df_lc, show_nbr_figures, save_output):
 
         # Iterate over bands and plot light curves.
         # IceCube needs to be done last so that we know the y-axis limits.
-        cleaned = _clean_lightcurves(singleobj_df)
-        band_groups = cleaned.groupby(["objectid", "band"])
-
-        # Now filter to just the ZTF bands
-        ztf_df = cleaned[cleaned["band"].isin(ZTF_BANDS)]
-
+        band_groups = _clean_lightcurves(singleobj_df).groupby('band')
         max_fluxes = band_groups.flux.max()  # max flux per band
-        for (objectid_val, band_name), band_df in band_groups:
-            if band_name == ICECUBE_BAND:
+        for band, band_df in band_groups:
+            if band == ICECUBE_BAND:
                 continue
-            _plot_lightcurve(band_name, band_df, axes, max_fluxes)
+            _plot_lightcurve(band, band_df, axes, max_fluxes)
         if ICECUBE_BAND in band_groups.groups:
             _plot_lightcurve(ICECUBE_BAND, band_groups.get_group(ICECUBE_BAND), axes)
 


### PR DESCRIPTION
This PR reverts part of #447 which is causing the plotting function to exit early, so only one figure gets displayed (instead of five) and its axes are not formatted correctly and the legend is missing. The problem is caused by `ztf_time_min_max` having an unexpected type, which itself is caused by the dataframes in `band_groups` having an unexpected index because the `groupby` was changed. The cell is actually throwing an error which probably went unnoticed because it's the last code cell and a figure still gets displayed.

I made a fresh clone of this repo on the Fornax Science Console today and ran all of the notebooks and checked them carefully for any errors. The scale_up notebook hit an error (I believe it was on an archive call) but it was transient. I ran scale_up ~~two~~ three more times later in the day and it's running fine. No other notebooks had problems.