### PR TITLE
MAINT: small infrastructure updates to address recent CI issues

### DIFF
--- a/light_curves/scale_up.md
+++ b/light_curves/scale_up.md
@@ -10,6 +10,8 @@ kernelspec:
   display_name: py-scale_up
   language: python
   name: py-scale_up
+execution:
+  timeout: 1200
 ---
 
 # Make Multi-Wavelength Light Curves for Large Samples

--- a/spectroscopy/requirements_spectra_collector.txt
+++ b/spectroscopy/requirements_spectra_collector.txt
@@ -8,8 +8,8 @@ pandas
 # compatible yet
 # sparclclient
 astropy
-# due to Spectrum1D rename to Spectrum
-specutils>=1.20
+# due to Spectrum1D rename to Spectrum and an internap spectutils bug
+specutils>=1.20.1
 # due to astroquery.mast fixes
 astroquery>=0.4.11.dev0
 fsspec

--- a/spectroscopy/spectra_collector.md
+++ b/spectroscopy/spectra_collector.md
@@ -9,6 +9,8 @@ kernelspec:
   name: py-spectra_collector
   display_name: py-spectra_collector
   language: python
+execution:
+  timeout: 1200
 ---
 
 # Extract Multi-Wavelength Spectroscopy from Archival Data

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ allowlist_externals =
 commands =
     pip freeze
 
-    buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=auto -nWT --keep-going
+    buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=cache -nWT --keep-going
     # SED magic to remove the toctree captions from the rendered index page while keeping them in the sidebar TOC
     buildhtml: sed -E -i.bak '/caption-text/{N; s/.+caption-text.+\n<ul>/<ul>/; P;D;}' _build/html/index.html
     buildhtml: bash -c 'rm _build/html/index.html.bak'


### PR DESCRIPTION
 - bump timeout to notebooks that more regularly produce CellTimeoutErrors in the cron jobs (that usually comes from the executer and not the remote services)

- noticed an incorrect lower dependency requirement, using that version triggered a specutils internal bug, so bumped it up with a minor version

- trying to use the cache in CI -- may not yet work pending CI paths/etc


Locally the slowest cells in these 2 notebooks were:

```
============================= slowest 10 durations =============================
688.18s call     spectroscopy/spectra_collector.ipynb::Cell 10
214.15s call     light_curves/scale_up.ipynb::Cell 15
181.16s call     spectroscopy/spectra_collector.ipynb::Cell 9
29.60s call     spectroscopy/spectra_collector.ipynb::Cell 8
26.94s call     spectroscopy/spectra_collector.ipynb::Cell 6
23.14s call     spectroscopy/spectra_collector.ipynb::Cell 7
2.25s call     spectroscopy/spectra_collector.ipynb::Cell 14
1.46s call     spectroscopy/spectra_collector.ipynb::Cell 1
1.24s call     light_curves/scale_up.ipynb::Cell 22
1.11s setup    light_curves/scale_up.ipynb::Cell 0
```