### PR TITLE
Bump to sparclclient>=1.3.0

### DIFF
--- a/spectroscopy/requirements_spectra_collector.txt
+++ b/spectroscopy/requirements_spectra_collector.txt
@@ -4,7 +4,8 @@
 numpy
 matplotlib
 pandas
-sparclclient>=1.2.8
+# sparclclient<1.3.0 causes https://github.com/nasa-fornax/fornax-demo-notebooks/issues/677
+sparclclient>=1.3.0
 astropy
 # pin is due to Spectrum1D rename to Spectrum and an internap spectutils bug
 specutils>=1.20.1


### PR DESCRIPTION
#677 is back in https://github.com/nasa-fornax/fornax-images/issues/198. I now strongly suspect that the resolution is to pin sparcclient>=1.3.0, so that's what this PR does.

We thought we resolved this in our GHA job by bumping to python=3.13 but that's probably because it pulled in sparcclient=1.3.0 as a side effect rather than being due to the python upgrade itself. See https://github.com/nasa-fornax/fornax-demo-notebooks/issues/677#issuecomment-5210963836 for details.